### PR TITLE
自定义切面的模式下,数据源增加DS注解一样的解析流程,可以从header,session中获取数据

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -111,7 +111,9 @@ public class DynamicDataSourceAutoConfiguration {
 
     @Bean
     @ConditionalOnBean(DynamicDataSourceConfigure.class)
-    public DynamicDataSourceAdvisor dynamicAdvisor(DynamicDataSourceConfigure dynamicDataSourceConfigure) {
-        return new DynamicDataSourceAdvisor(dynamicDataSourceConfigure.getMatchers());
+    public DynamicDataSourceAdvisor dynamicAdvisor(DynamicDataSourceConfigure dynamicDataSourceConfigure, DsProcessor dsProcessor) {
+        DynamicDataSourceAdvisor advisor = new DynamicDataSourceAdvisor(dynamicDataSourceConfigure.getMatchers());
+        advisor.setDsProcessor(dsProcessor);
+        return advisor;
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
自定义切面的模式下,数据源增加DS注解一样的解析流程,可以从header,session中获取数据

例如
```java
@Configuration
public class DynamicConfiguration {
    @Bean
    public DynamicDataSourceConfigure dynamicDataSourceConfigure() {
        return DynamicDataSourceConfigure.config()
                .regexMatchers("com.baomidou.samples.nest.service.impl.*select.*", "#session.dsName")
                .regexMatchers("com.baomidou.samples.nest.service.impl.*find.*", "#header.organization")
                .expressionMatchers("execution(* com.baomidou.samples.nest.service.impl.*.select*(..))", "mysql");
    }
}
```

**Other information:**
多租户场景中,如果是分库模式(每个租户一个数据库,应用是同一个),每个请求默认可以分发到对应的数据库中, 特殊需要切换数据的情况,可以根据@DS进行替换


