### PR TITLE
集成分布式事务 Seata 导致DruidDynamicDataSourceConfiguration 被加载 报错

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/druid/DruidDynamicDataSourceConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/druid/DruidDynamicDataSourceConfiguration.java
@@ -16,7 +16,6 @@
  */
 package com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid;
 
-import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.spring.boot.autoconfigure.properties.DruidStatProperties;
 import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidFilterConfiguration;
 import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidSpringAopConfiguration;
@@ -34,13 +33,13 @@ import org.springframework.context.annotation.Import;
  * @since 1.1.0
  */
 @Configuration
-@ConditionalOnClass(DruidDataSource.class)
+@ConditionalOnClass(DruidStatProperties.class)
 @EnableConfigurationProperties({DruidStatProperties.class})
 @Import({
-    DruidSpringAopConfiguration.class,
-    DruidStatViewServletConfiguration.class,
-    DruidWebStatFilterConfiguration.class,
-    DruidFilterConfiguration.class})
+        DruidSpringAopConfiguration.class,
+        DruidStatViewServletConfiguration.class,
+        DruidWebStatFilterConfiguration.class,
+        DruidFilterConfiguration.class})
 public class DruidDynamicDataSourceConfiguration {
 
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**

集成分布式事务 Seata 导致DruidDynamicDataSourceConfiguration 被加载 
Seata 只使用 Druid 数据源   
DruidDynamicDataSourceConfiguration 是starter 的定义
**Other information:**



