### PR TITLE
#新增从数据库中初始化其他数据源

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/provider/MysqlDynamicDataSourceProvider.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/provider/MysqlDynamicDataSourceProvider.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright © 2018 organization baomidou
+ * <pre>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <pre/>
+ */
+package com.baomidou.dynamic.datasource.provider;
+
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.util.StringUtils;
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+     * @ProjectName:    从数据库中获取数据库信息并初始化
+     * @Package:        cn.gwssi.task.config
+     * @ClassName:      DynamicDataSourceProviderImpl
+     * @Description:    java类作用描述
+     * @Author:         胡铭锋
+     * @CreateDate:     2019/12/18 2:25 下午
+     * @Version:        1.0
+     */
+public class MysqlDynamicDataSourceProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(MysqlDynamicDataSourceProvider.class);
+
+    /**
+     * DRUID数据源类
+     */
+    private static final String DRUID_DATASOURCE = "com.alibaba.druid.pool.DruidDataSource";
+    /**
+     * HikariCp数据源
+     */
+    private static final String HIKARI_DATASOURCE = "com.zaxxer.hikari.HikariDataSource";
+
+    /**
+     * 数据源表建表语句
+     */
+    private static String CREATE_TABLE_IF_NOT_EXISTS;
+
+    static {
+        CREATE_TABLE_IF_NOT_EXISTS = "CREATE TABLE IF NOT EXISTS `data_source_config` (\n" +
+                "  ID int(11) NOT NULL AUTO_INCREMENT,\n" +
+                "  USER_NAME varchar(255) DEFAULT NULL COMMENT '用户名',\n" +
+                "  PASSWORD varchar(255) DEFAULT NULL COMMENT '密码',\n" +
+                "  URL varchar(255) DEFAULT NULL COMMENT '地址',\n" +
+                "  DRIVER_CLASS_NAME varchar(500) DEFAULT NULL COMMENT '驱动',\n" +
+                "  DB_NAME varchar(255) DEFAULT NULL COMMENT '数据源名称',\n" +
+                "  TYPE varchar(255) DEFAULT NULL COMMENT '数据源类型',\n" +
+                "  PRIMARY KEY (ID)\n" +
+                ") ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4;";
+    }
+
+    public Map<String, DataSourceProperty> run(DataSource dataSource) {
+
+        try {
+            JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+
+            //如果表不存在则建立
+            jdbcTemplate.execute(CREATE_TABLE_IF_NOT_EXISTS);
+
+            List<Map<String, Object>> maps = jdbcTemplate.queryForList("SELECT TYPE,DB_NAME,USER_NAME,PASSWORD,URL,DRIVER_CLASS_NAME FROM DATA_SOURCE_CONFIG");
+
+            Map<String, DataSourceProperty> dataSourcePropertiesMap = new HashMap<>(3);
+
+            for(Map<String, Object> map : maps) {
+                String type = map.get("TYPE")==null?"":map.get("TYPE").toString();
+                String db_name = map.get("DB_NAME")==null?"":map.get("DB_NAME").toString();
+                String user_name = map.get("USER_NAME")==null?"":map.get("USER_NAME").toString();
+                String password = map.get("PASSWORD")==null?"":map.get("PASSWORD").toString();
+                String url = map.get("URL")==null?"":map.get("URL").toString();
+                String driver_class_name = map.get("DRIVER_CLASS_NAME")==null?"":map.get("DRIVER_CLASS_NAME").toString();
+                if (StringUtils.isEmpty(db_name)
+                        || StringUtils.isEmpty(user_name)
+                        || StringUtils.isEmpty(password)
+                        || StringUtils.isEmpty(url)
+                        || StringUtils.isEmpty(driver_class_name)) {
+                    log.error("param contain wrong in DATA_SOURCE_CONFIG  ");
+                    return null;
+                }
+
+                DataSourceProperty dataSourceProperty = new DataSourceProperty();
+                dataSourceProperty.setUrl(url);
+                dataSourceProperty.setUsername(user_name);
+                dataSourceProperty.setPassword(password);
+                dataSourceProperty.setDriverClassName(driver_class_name);
+                switch (type) {
+                    case DRUID_DATASOURCE:
+                        dataSourceProperty.setType(DruidDataSource.class);
+                        break;
+                    case HIKARI_DATASOURCE:
+                        dataSourceProperty.setType(HikariDataSource.class);
+                        break;
+                    default:
+                        break;
+                }
+                dataSourcePropertiesMap.put(db_name,dataSourceProperty);
+            }
+            log.debug("others in DATA_SOURCE_CONFIG:"+dataSourcePropertiesMap);
+            return dataSourcePropertiesMap;
+        }catch (Exception e){
+            log.warn("init data_source_config error:"+e.getLocalizedMessage());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/provider/YmlDynamicDataSourceProvider.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/provider/YmlDynamicDataSourceProvider.java
@@ -37,13 +37,30 @@ public class YmlDynamicDataSourceProvider extends AbstractDataSourceProvider imp
    */
   private DynamicDataSourceProperties properties;
 
+  /**
+   * 数据库配置表初始化数据源
+   */
+  private MysqlDynamicDataSourceProvider mysqlDynamicDataSourceProvider = new MysqlDynamicDataSourceProvider();
+
   public YmlDynamicDataSourceProvider(DynamicDataSourceProperties properties) {
     this.properties = properties;
   }
 
   @Override
   public Map<String, DataSource> loadDataSources() {
-    Map<String, DataSourceProperty> dataSourcePropertiesMap = properties.getDatasource();
-    return createDataSourceMap(dataSourcePropertiesMap);
+
+      Map<String, DataSourceProperty> dataSourcePropertiesMap = properties.getDatasource();
+      Map<String, DataSource> dataSourceMap = createDataSourceMap(dataSourcePropertiesMap);
+
+      /**
+       *    在此处获取其他数据库配置的数据源
+       */
+      Map<String, DataSourceProperty> otherMap = mysqlDynamicDataSourceProvider.run(dataSourceMap.get(properties.getPrimary()));
+
+      Map<String, DataSource> otherDataSourceMap = createDataSourceMap(otherMap);
+
+      dataSourceMap.putAll(otherDataSourceMap);
+
+      return dataSourceMap;
   }
 }


### PR DESCRIPTION
**The description of the PR:**
新增从数据库表中初始化数据源：
功能介绍：
    现在启动时会在从配置文件中初始化数据源后再从默认数据库表中初始化其他数据源，如果数据源表不存在会自动建表，如果存在则从配置表中读取其他数据源配置信息，并进行初始化。

*MysqlDynamicDataSourceProvider为新增类
*data_source_config 为数据源配置表，不需要手动建，表不存在会自动创建
*表中字段为
  USER_NAME varchar(255)   '用户名',
  PASSWORD varchar(255)   '密码',
  URL varchar(255)   '地址',
  DRIVER_CLASS_NAME   '驱动',
  DB_NAME  '数据源名称',
  TYPE   '数据源类型',

==>  TYPE内容支持内容：1、com.alibaba.druid.pool.DruidDataSource
                                              2、com.alibaba.druid.pool.DruidDataSource
                                              3、空，则自动创建BasicDataSource


**Other information:**
默认库如果非MySQL或者Oracle，需要改动建表语句自己打包
PS:欢迎STAR，并关注


