### PR TITLE
支持从父类接口获取DS注解

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/support/DataSourceClassResolver.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/support/DataSourceClassResolver.java
@@ -175,7 +175,12 @@ public class DataSourceClassResolver {
         if (mpEnabled) {
             final Class<?> clazz = getMapperInterfaceClass(targetObject);
             if (clazz != null) {
-                return findDataSourceAttribute(clazz);
+                String datasourceAttr = findDataSourceAttribute(clazz);
+                if (datasourceAttr != null) {
+                    return datasourceAttr;
+                }
+                // 尝试从其父接口获取
+                return findDataSourceAttribute(clazz.getSuperclass());
             }
         }
         return null;


### PR DESCRIPTION
支持如下情况获取DS的注解
@Mapper
public interface OrderItemDao extends BaseDao<OrderItemEntity> {}
@DS("master")
public interface BaseDao<T> extends BaseMapper<T> {}

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] **_Feature_**
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
需求：动态改变DS的值，只需在父类接口标识DS注解，反射时根据需要动态修改即可。
           无需标识所有子类接口，易于管理等。

**Other information:**
版本3.0.0是支持的


