### PR TITLE
重构DataSourceCreator的创建规则， 修复不存在DruidDataSource类时， 无法自动创建。

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/creator/BasicDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/BasicDataSourceCreator.java
@@ -20,9 +20,13 @@ import com.baomidou.dynamic.datasource.exception.ErrorCreateDataSourceException;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.util.StringUtils;
 
 import javax.sql.DataSource;
 import java.lang.reflect.Method;
+
+import static com.baomidou.dynamic.datasource.creator.DataSourceCreator.DEFAULT_ORDER;
 
 /**
  * 基础数据源创建器
@@ -32,7 +36,8 @@ import java.lang.reflect.Method;
  */
 @Data
 @Slf4j
-public class BasicDataSourceCreator {
+@Order(DEFAULT_ORDER)
+public class BasicDataSourceCreator implements DataSourceCreator {
 
     private static Method createMethod;
     private static Method typeMethod;
@@ -75,9 +80,14 @@ public class BasicDataSourceCreator {
      * 创建基础数据源
      *
      * @param dataSourceProperty 数据源参数
+     * @param publicKey
      * @return 数据源
      */
-    public DataSource createDataSource(DataSourceProperty dataSourceProperty) {
+    @Override
+    public DataSource createDataSource(DataSourceProperty dataSourceProperty, String publicKey) {
+        if (StringUtils.isEmpty(dataSourceProperty.getPublicKey())) {
+            dataSourceProperty.setPublicKey(publicKey);
+        }
         try {
             Object o1 = createMethod.invoke(null);
             Object o2 = typeMethod.invoke(o1, dataSourceProperty.getType());
@@ -90,6 +100,11 @@ public class BasicDataSourceCreator {
             throw new ErrorCreateDataSourceException(
                     "dynamic-datasource create basic database named " + dataSourceProperty.getPoolName() + " error");
         }
+    }
+
+    @Override
+    public boolean support(DataSourceProperty dataSourceProperty) {
+        return true;
     }
 
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/CompositeDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/CompositeDataSourceCreator.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright © 2018 organization baomidou
+ * <pre>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <pre/>
+ */
+package com.baomidou.dynamic.datasource.creator;
+
+import com.baomidou.dynamic.datasource.ds.ItemDataSource;
+import com.baomidou.dynamic.datasource.enums.SeataMode;
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties;
+import com.baomidou.dynamic.datasource.support.ScriptRunner;
+import com.p6spy.engine.spy.P6DataSource;
+import io.seata.rm.datasource.DataSourceProxy;
+import io.seata.rm.datasource.xa.DataSourceProxyXA;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+/**
+ * 数据源创建器
+ *
+ * @author TaoYu
+ * @since 2.3.0
+ */
+@Slf4j
+@Setter
+public class CompositeDataSourceCreator implements DataSourceCreator {
+
+    private DynamicDataSourceProperties properties;
+    private List<DataSourceCreator> dataSourceCreator;
+
+    /**
+     * 创建数据源
+     *
+     * @param dataSourceProperty 数据源信息
+     * @return 数据源
+     */
+    @Override
+    public DataSource createDataSource(DataSourceProperty dataSourceProperty, String publicKey) {
+        DataSourceCreator factory = null;
+        for (DataSourceCreator dataSourceCreator : this.dataSourceCreator) {
+            if (dataSourceCreator.support(dataSourceProperty)) {
+                factory = dataSourceCreator;
+                break;
+            }
+        }
+        if (factory == null) {
+            throw new IllegalStateException("factory must not be null,please check the DataSourceCreator");
+        }
+        DataSource dataSource = factory.createDataSource(dataSourceProperty, properties.getPublicKey());
+        this.runScrip(dataSource, dataSourceProperty);
+        return wrapDataSource(dataSource, dataSourceProperty);
+    }
+
+
+    private void runScrip(DataSource dataSource, DataSourceProperty dataSourceProperty) {
+        String schema = dataSourceProperty.getSchema();
+        String data = dataSourceProperty.getData();
+        if (StringUtils.hasText(schema) || StringUtils.hasText(data)) {
+            ScriptRunner scriptRunner = new ScriptRunner(dataSourceProperty.isContinueOnError(), dataSourceProperty.getSeparator());
+            if (StringUtils.hasText(schema)) {
+                scriptRunner.runScript(dataSource, schema);
+            }
+            if (StringUtils.hasText(data)) {
+                scriptRunner.runScript(dataSource, data);
+            }
+        }
+    }
+
+    private DataSource wrapDataSource(DataSource dataSource, DataSourceProperty dataSourceProperty) {
+        String name = dataSourceProperty.getPoolName();
+        DataSource targetDataSource = dataSource;
+
+        Boolean enabledP6spy = properties.getP6spy() && dataSourceProperty.getP6spy();
+        if (enabledP6spy) {
+            targetDataSource = new P6DataSource(dataSource);
+            log.debug("dynamic-datasource [{}] wrap p6spy plugin", name);
+        }
+
+        Boolean enabledSeata = properties.getSeata() && dataSourceProperty.getSeata();
+        SeataMode seataMode = properties.getSeataMode();
+        if (enabledSeata) {
+            targetDataSource = SeataMode.XA == seataMode ? new DataSourceProxyXA(dataSource) : new DataSourceProxy(dataSource);
+            log.debug("dynamic-datasource [{}] wrap seata plugin transaction mode [{}]", name, seataMode);
+        }
+        return new ItemDataSource(name, dataSource, targetDataSource, enabledP6spy, enabledSeata, seataMode);
+    }
+
+
+    public void setDataSourceCreatorFactory(List<DataSourceCreator> dataSourceCreator) {
+        this.dataSourceCreator = dataSourceCreator;
+    }
+
+
+    @Override
+    public boolean support(DataSourceProperty dataSourceProperty) {
+        return true;
+    }
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/DataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/DataSourceCreator.java
@@ -16,175 +16,26 @@
  */
 package com.baomidou.dynamic.datasource.creator;
 
-import com.baomidou.dynamic.datasource.ds.ItemDataSource;
-import com.baomidou.dynamic.datasource.enums.SeataMode;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties;
-import com.baomidou.dynamic.datasource.support.ScriptRunner;
-import com.p6spy.engine.spy.P6DataSource;
-import io.seata.rm.datasource.DataSourceProxy;
-import io.seata.rm.datasource.xa.DataSourceProxyXA;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.util.StringUtils;
 
 import javax.sql.DataSource;
 
-import static com.baomidou.dynamic.datasource.support.DdConstants.DRUID_DATASOURCE;
-import static com.baomidou.dynamic.datasource.support.DdConstants.HIKARI_DATASOURCE;
-
 /**
- * 数据源创建器
- *
- * @author TaoYu
- * @since 2.3.0
+ * @author ls9527
  */
-@Slf4j
-@Setter
-public class DataSourceCreator {
+public interface DataSourceCreator {
+    int JNDI_ORDER = 1000;
+
+    int DEFAULT_ORDER = 5000;
 
     /**
-     * 是否存在druid
-     */
-    private static Boolean druidExists = false;
-    /**
-     * 是否存在hikari
-     */
-    private static Boolean hikariExists = false;
-
-    static {
-        try {
-            Class.forName(DRUID_DATASOURCE);
-            druidExists = true;
-        } catch (ClassNotFoundException ignored) {
-        }
-        try {
-            Class.forName(HIKARI_DATASOURCE);
-            hikariExists = true;
-        } catch (ClassNotFoundException ignored) {
-        }
-    }
-
-    private BasicDataSourceCreator basicDataSourceCreator;
-    private JndiDataSourceCreator jndiDataSourceCreator;
-    private HikariDataSourceCreator hikariDataSourceCreator;
-    private DruidDataSourceCreator druidDataSourceCreator;
-    private DynamicDataSourceProperties properties;
-
-    /**
-     * 创建数据源
+     * create DataSource by DataSourceProperty
      *
-     * @param dataSourceProperty 数据源信息
-     * @return 数据源
+     * @param dataSourceProperty
+     * @param publicKey
+     * @return
      */
-    public DataSource createDataSource(DataSourceProperty dataSourceProperty) {
-        DataSource dataSource;
-        //如果是jndi数据源
-        String jndiName = dataSourceProperty.getJndiName();
-        if (jndiName != null && !jndiName.isEmpty()) {
-            dataSource = createJNDIDataSource(jndiName);
-        } else {
-            Class<? extends DataSource> type = dataSourceProperty.getType();
-            if (type == null) {
-                if (druidExists) {
-                    dataSource = createDruidDataSource(dataSourceProperty);
-                } else if (hikariExists) {
-                    dataSource = createHikariDataSource(dataSourceProperty);
-                } else {
-                    dataSource = createBasicDataSource(dataSourceProperty);
-                }
-            } else if (DRUID_DATASOURCE.equals(type.getName())) {
-                dataSource = createDruidDataSource(dataSourceProperty);
-            } else if (HIKARI_DATASOURCE.equals(type.getName())) {
-                dataSource = createHikariDataSource(dataSourceProperty);
-            } else {
-                dataSource = createBasicDataSource(dataSourceProperty);
-            }
-        }
-        this.runScrip(dataSource, dataSourceProperty);
-        return wrapDataSource(dataSource, dataSourceProperty);
-    }
+    DataSource createDataSource(DataSourceProperty dataSourceProperty, String publicKey);
 
-    private void runScrip(DataSource dataSource, DataSourceProperty dataSourceProperty) {
-        String schema = dataSourceProperty.getSchema();
-        String data = dataSourceProperty.getData();
-        if (StringUtils.hasText(schema) || StringUtils.hasText(data)) {
-            ScriptRunner scriptRunner = new ScriptRunner(dataSourceProperty.isContinueOnError(), dataSourceProperty.getSeparator());
-            if (StringUtils.hasText(schema)) {
-                scriptRunner.runScript(dataSource, schema);
-            }
-            if (StringUtils.hasText(data)) {
-                scriptRunner.runScript(dataSource, data);
-            }
-        }
-    }
-
-    private DataSource wrapDataSource(DataSource dataSource, DataSourceProperty dataSourceProperty) {
-        String name = dataSourceProperty.getPoolName();
-        DataSource targetDataSource = dataSource;
-
-        Boolean enabledP6spy = properties.getP6spy() && dataSourceProperty.getP6spy();
-        if (enabledP6spy) {
-            targetDataSource = new P6DataSource(dataSource);
-            log.debug("dynamic-datasource [{}] wrap p6spy plugin", name);
-        }
-
-        Boolean enabledSeata = properties.getSeata() && dataSourceProperty.getSeata();
-        SeataMode seataMode = properties.getSeataMode();
-        if (enabledSeata) {
-            targetDataSource = SeataMode.XA == seataMode ? new DataSourceProxyXA(dataSource) : new DataSourceProxy(dataSource);
-            log.debug("dynamic-datasource [{}] wrap seata plugin transaction mode [{}]", name, seataMode);
-        }
-        return new ItemDataSource(name, dataSource, targetDataSource, enabledP6spy, enabledSeata, seataMode);
-    }
-
-    /**
-     * 创建基础数据源
-     *
-     * @param dataSourceProperty 数据源参数
-     * @return 数据源
-     */
-    public DataSource createBasicDataSource(DataSourceProperty dataSourceProperty) {
-        if (StringUtils.isEmpty(dataSourceProperty.getPublicKey())) {
-            dataSourceProperty.setPublicKey(properties.getPublicKey());
-        }
-        return basicDataSourceCreator.createDataSource(dataSourceProperty);
-    }
-
-    /**
-     * 创建JNDI数据源
-     *
-     * @param jndiName jndi数据源名称
-     * @return 数据源
-     */
-    public DataSource createJNDIDataSource(String jndiName) {
-        return jndiDataSourceCreator.createDataSource(jndiName);
-    }
-
-    /**
-     * 创建Druid数据源
-     *
-     * @param dataSourceProperty 数据源参数
-     * @return 数据源
-     */
-    public DataSource createDruidDataSource(DataSourceProperty dataSourceProperty) {
-        if (StringUtils.isEmpty(dataSourceProperty.getPublicKey())) {
-            dataSourceProperty.setPublicKey(properties.getPublicKey());
-        }
-        return druidDataSourceCreator.createDataSource(dataSourceProperty);
-    }
-
-    /**
-     * 创建Hikari数据源
-     *
-     * @param dataSourceProperty 数据源参数
-     * @return 数据源
-     * @author 离世庭院 小锅盖
-     */
-    public DataSource createHikariDataSource(DataSourceProperty dataSourceProperty) {
-        if (StringUtils.isEmpty(dataSourceProperty.getPublicKey())) {
-            dataSourceProperty.setPublicKey(properties.getPublicKey());
-        }
-        return hikariDataSourceCreator.createDataSource(dataSourceProperty);
-    }
+    boolean support(DataSourceProperty dataSourceProperty);
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/JndiDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/JndiDataSourceCreator.java
@@ -16,9 +16,13 @@
  */
 package com.baomidou.dynamic.datasource.creator;
 
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
 
 import javax.sql.DataSource;
+
+import static com.baomidou.dynamic.datasource.creator.DataSourceCreator.JNDI_ORDER;
 
 /**
  * JNDI数据源创建器
@@ -26,18 +30,27 @@ import javax.sql.DataSource;
  * @author TaoYu
  * @since 2020/1/27
  */
-public class JndiDataSourceCreator {
+@Order(JNDI_ORDER)
+public class JndiDataSourceCreator implements DataSourceCreator {
 
     private static final JndiDataSourceLookup LOOKUP = new JndiDataSourceLookup();
 
+
     /**
-     * 创建基础数据源
+     * 创建JNDI数据源
      *
-     * @param name 数据源参数
+     * @param dataSourceProperty jndi数据源名称
+     * @param publicKey publicKey
      * @return 数据源
      */
-    public DataSource createDataSource(String name) {
-        return LOOKUP.getDataSource(name);
+    @Override
+    public DataSource createDataSource(DataSourceProperty dataSourceProperty, String publicKey) {
+        return LOOKUP.getDataSource(dataSourceProperty.getJndiName());
     }
 
+    @Override
+    public boolean support(DataSourceProperty dataSourceProperty) {
+        String jndiName = dataSourceProperty.getJndiName();
+        return jndiName != null && !jndiName.isEmpty();
+    }
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/provider/AbstractDataSourceProvider.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/provider/AbstractDataSourceProvider.java
@@ -16,7 +16,7 @@
  */
 package com.baomidou.dynamic.datasource.provider;
 
-import com.baomidou.dynamic.datasource.creator.DataSourceCreator;
+import com.baomidou.dynamic.datasource.creator.CompositeDataSourceCreator;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +30,7 @@ import java.util.Map;
 public abstract class AbstractDataSourceProvider implements DynamicDataSourceProvider {
 
     @Autowired
-    private DataSourceCreator dataSourceCreator;
+    private CompositeDataSourceCreator compositeDataSourceCreator;
 
     protected Map<String, DataSource> createDataSourceMap(
             Map<String, DataSourceProperty> dataSourcePropertiesMap) {
@@ -42,7 +42,7 @@ public abstract class AbstractDataSourceProvider implements DynamicDataSourcePro
                 poolName = item.getKey();
             }
             dataSourceProperty.setPoolName(poolName);
-            dataSourceMap.put(poolName, dataSourceCreator.createDataSource(dataSourceProperty));
+            dataSourceMap.put(poolName, compositeDataSourceCreator.createDataSource(dataSourceProperty,null));
         }
         return dataSourceMap;
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

DataSourceCreator 的规则，对外部扩展不友好。通过集成spring的Order方式， 支持外部扩增数据源创建器。

当DruidDataSource不存在时，DataSourceCreator 也无法默认选择。  这里修复了spring创建 DruidDataSourceCreator 的方式


- [ ] Bugfix
- [x] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**


**Other information:**



