### PR TITLE
Optimize/checkmode 1117

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/DynamicRoutingDataSource.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/DynamicRoutingDataSource.java
@@ -128,6 +128,10 @@ public class DynamicRoutingDataSource extends AbstractRoutingDataSource implemen
         return determinePrimaryDataSource();
     }
 
+    /**
+     * 调用栈异常
+     * 用于打印调用栈, 无异常含义
+     */
     private static class StackTraceException extends Exception {
     }
 

--- a/src/main/java/com/baomidou/dynamic/datasource/enums/CheckMode.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/enums/CheckMode.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright © 2018 organization baomidou
+ * <pre>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <pre/>
+ */
+package com.baomidou.dynamic.datasource.enums;
+
+public enum CheckMode {
+    /**
+     * 严格模式
+     * 无法匹配数据源时，抛出异常
+     */
+    STRICT,
+    /**
+     * 调用栈日志模式
+     * 无法匹配数据源时，打印日志
+     */
+    STACK_LOG,
+    /**
+     * 普通日志模式
+     * 无法匹配数据源时，打印日志
+     */
+    LOG,
+    /**
+     * 无法匹配数据源时, 什么也不做,默认选择主数据源
+     */
+    NONE;
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -76,6 +76,7 @@ public class DynamicDataSourceAutoConfiguration {
         DynamicRoutingDataSource dataSource = new DynamicRoutingDataSource();
         dataSource.setPrimary(properties.getPrimary());
         dataSource.setStrict(properties.getStrict());
+        dataSource.setCheckMode(properties.getCheckMode());
         dataSource.setStrategy(properties.getStrategy());
         dataSource.setProvider(dynamicDataSourceProvider);
         dataSource.setP6spy(properties.getP6spy());

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
@@ -16,6 +16,7 @@
  */
 package com.baomidou.dynamic.datasource.spring.boot.autoconfigure;
 
+import com.baomidou.dynamic.datasource.enums.CheckMode;
 import com.baomidou.dynamic.datasource.enums.SeataMode;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConfig;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.hikari.HikariCpConfig;
@@ -65,6 +66,10 @@ public class DynamicDataSourceProperties {
      * 是否使用开启seata，默认不开启
      */
     private Boolean seata = false;
+    /**
+     * 无法匹配数据源时的检查模式
+     */
+    private CheckMode checkMode = CheckMode.STACK_LOG;
     /**
      * seata使用模式，默认AT
      */


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
原先的strict改为 checkMode, 同时也对原先的配置进行支持。

默认checkMode=STACK_LOG, 当无法正确匹配数据源时，打印调用栈，期望匹配的数据源名称，目前已有的所有数据源名称

可以通过STRICT报错，  LOG不打印调用栈， NONE什么也不做。

除了STRICT 都会选择默认数据源

**Other information:**



