### PR TITLE
optimize  纯分页兼容mp和健康检查优化 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.baomidou</groupId>
     <artifactId>dynamic-datasource-spring-boot-starter</artifactId>
-    <version>3.2.1</version>
+    <version>3.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>dynamic-datasource-spring-boot-starter</name>
@@ -143,6 +143,30 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -161,30 +185,6 @@
             </distributionManagement>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>

--- a/src/main/java/com/baomidou/dynamic/datasource/ds/GroupDataSource.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/ds/GroupDataSource.java
@@ -61,10 +61,16 @@ public class GroupDataSource {
     }
 
     public DataSource determineDataSource() {
-        return dynamicDataSourceStrategy.determineDataSource(new ArrayList<>(dataSourceMap.values()));
+        String dsKey = determineDsKey();
+        return dataSourceMap.get(dsKey);
+    }
+
+    public String determineDsKey() {
+        return dynamicDataSourceStrategy.determineDSKey(new ArrayList<>(dataSourceMap.keySet()));
     }
 
     public int size() {
         return dataSourceMap.size();
     }
+
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/exception/CannotSelectDataSourceException.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/exception/CannotSelectDataSourceException.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright © 2018 organization baomidou
+ * <pre>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <pre/>
+ */
+package com.baomidou.dynamic.datasource.exception;
+
+/**
+ * exception when  druid dataSource cannot select
+ *
+ * @author TaoYu
+ * @since 2.5.6
+ */
+public class CannotSelectDataSourceException extends RuntimeException {
+
+    public CannotSelectDataSourceException(String message) {
+        super(message);
+    }
+
+    public CannotSelectDataSourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -57,7 +57,7 @@ import java.util.Map;
 @AllArgsConstructor
 @EnableConfigurationProperties(DynamicDataSourceProperties.class)
 @AutoConfigureBefore(DataSourceAutoConfiguration.class)
-@Import(value = {DruidDynamicDataSourceConfiguration.class, DynamicDataSourceCreatorAutoConfiguration.class})
+@Import(value = {DruidDynamicDataSourceConfiguration.class, DynamicDataSourceCreatorAutoConfiguration.class, DynamicDataSourceHealthCheckConfiguration.class})
 @ConditionalOnProperty(prefix = DynamicDataSourceProperties.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
 public class DynamicDataSourceAutoConfiguration {
 

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceHealthCheckConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceHealthCheckConfiguration.java
@@ -17,6 +17,7 @@
 package com.baomidou.dynamic.datasource.spring.boot.autoconfigure;
 
 import com.baomidou.dynamic.datasource.support.DbHealthIndicator;
+import com.baomidou.dynamic.datasource.support.HealthCheckAdapter;
 import org.springframework.boot.actuate.autoconfigure.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -29,16 +30,29 @@ import javax.sql.DataSource;
 /**
  * @author liushang@zsyjr.com
  */
-@ConditionalOnClass(AbstractHealthIndicator.class)
-@ConditionalOnEnabledHealthIndicator("dynamicDS")
+
 @Configuration
 public class DynamicDataSourceHealthCheckConfiguration {
 
     private static final String DYNAMIC_HEALTH_CHECK = DynamicDataSourceProperties.PREFIX + ".health";
 
-    @Bean("dynamicDataSourceHealthCheck")
-    @ConditionalOnProperty(DYNAMIC_HEALTH_CHECK)
-    public DbHealthIndicator healthIndicator(DataSource dataSource, DynamicDataSourceProperties dynamicDataSourceProperties) {
-        return new DbHealthIndicator(dataSource, dynamicDataSourceProperties.getHealthValidQuery());
+    @Bean
+    public HealthCheckAdapter healthCheckAdapter() {
+        return new HealthCheckAdapter();
     }
+
+    @ConditionalOnClass(AbstractHealthIndicator.class)
+    @ConditionalOnEnabledHealthIndicator("dynamicDS")
+    public class HealthIndicatorConfiguration {
+
+        @Bean("dynamicDataSourceHealthCheck")
+        @ConditionalOnProperty(DYNAMIC_HEALTH_CHECK)
+        public DbHealthIndicator healthIndicator(DataSource dataSource,
+                                                 DynamicDataSourceProperties dynamicDataSourceProperties,
+                                                 HealthCheckAdapter healthCheckAdapter) {
+            return new DbHealthIndicator(dataSource, dynamicDataSourceProperties.getHealthValidQuery(), healthCheckAdapter);
+        }
+
+    }
+
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceHealthCheckConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceHealthCheckConfiguration.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright © 2018 organization baomidou
+ * <pre>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <pre/>
+ */
+package com.baomidou.dynamic.datasource.spring.boot.autoconfigure;
+
+import com.baomidou.dynamic.datasource.support.DbHealthIndicator;
+import org.springframework.boot.actuate.autoconfigure.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+/**
+ * @author liushang@zsyjr.com
+ */
+@ConditionalOnClass(AbstractHealthIndicator.class)
+@ConditionalOnEnabledHealthIndicator("dynamicDS")
+@Configuration
+public class DynamicDataSourceHealthCheckConfiguration {
+
+    private static final String DYNAMIC_HEALTH_CHECK = DynamicDataSourceProperties.PREFIX + ".health";
+
+    @Bean("dynamicDataSourceHealthCheck")
+    @ConditionalOnProperty(DYNAMIC_HEALTH_CHECK)
+    public DbHealthIndicator healthIndicator(DataSource dataSource, DynamicDataSourceProperties dynamicDataSourceProperties) {
+        return new DbHealthIndicator(dataSource, dynamicDataSourceProperties.getHealthValidQuery());
+    }
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
@@ -48,7 +48,7 @@ public class DynamicDataSourceProperties {
 
     public static final String PREFIX = "spring.datasource.dynamic";
     public static final String HEALTH = PREFIX + ".health";
-
+    public static final String DEFAULT_VALID_QUERY = "SELECT 1";
     /**
      * 必须设置默认的库,默认master
      */
@@ -73,6 +73,10 @@ public class DynamicDataSourceProperties {
      * 是否使用 spring actuator 监控检查，默认不检查
      */
     private boolean health = false;
+    /**
+     * 监控检查SQL
+     */
+    private String healthValidQuery = DEFAULT_VALID_QUERY;
     /**
      * 每一个数据源
      */

--- a/src/main/java/com/baomidou/dynamic/datasource/strategy/DynamicDataSourceStrategy.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/strategy/DynamicDataSourceStrategy.java
@@ -17,6 +17,7 @@
 package com.baomidou.dynamic.datasource.strategy;
 
 import javax.sql.DataSource;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -35,5 +36,14 @@ public interface DynamicDataSourceStrategy {
      * @param dataSources given dataSources
      * @return final dataSource
      */
+    @Deprecated
     DataSource determineDataSource(List<DataSource> dataSources);
+
+    /**
+     * determine a database from the given dataSources
+     *
+     * @param dsNames given dataSources
+     * @return final dataSource
+     */
+    String determineDSKey(List<String> dsNames);
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/strategy/LoadBalanceDynamicDataSourceStrategy.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/strategy/LoadBalanceDynamicDataSourceStrategy.java
@@ -37,4 +37,9 @@ public class LoadBalanceDynamicDataSourceStrategy implements DynamicDataSourceSt
     public DataSource determineDataSource(List<DataSource> dataSources) {
         return dataSources.get(Math.abs(index.getAndAdd(1) % dataSources.size()));
     }
+
+    @Override
+    public String determineDSKey(List<String> dsNames) {
+        return dsNames.get(Math.abs(index.getAndAdd(1) % dsNames.size()));
+    }
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/strategy/RandomDynamicDataSourceStrategy.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/strategy/RandomDynamicDataSourceStrategy.java
@@ -32,4 +32,9 @@ public class RandomDynamicDataSourceStrategy implements DynamicDataSourceStrateg
     public DataSource determineDataSource(List<DataSource> dataSources) {
         return dataSources.get(ThreadLocalRandom.current().nextInt(dataSources.size()));
     }
+
+    @Override
+    public String determineDSKey(List<String> dsNames) {
+        return dsNames.get(ThreadLocalRandom.current().nextInt(dsNames.size()));
+    }
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/support/DbHealthIndicator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/support/DbHealthIndicator.java
@@ -19,6 +19,7 @@ package com.baomidou.dynamic.datasource.support;
 import com.baomidou.dynamic.datasource.DynamicRoutingDataSource;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.IncorrectResultSetColumnCountException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -60,7 +61,8 @@ public class DbHealthIndicator extends AbstractHealthIndicator {
      * @return 健康状况
      */
     public static boolean getDbHealth(String dataSource) {
-        return DB_HEALTH.get(dataSource);
+        Boolean isHealth = DB_HEALTH.get(dataSource);
+        return isHealth != null && isHealth;
     }
 
     /**
@@ -86,6 +88,7 @@ public class DbHealthIndicator extends AbstractHealthIndicator {
                 } finally {
                     DB_HEALTH.put(dataSource.getKey(), 1 == result);
                     builder.withDetail(dataSource.getKey(), result);
+                    builder.status(1 == result ? Status.UP : Status.DOWN);
                 }
             }
         }

--- a/src/main/java/com/baomidou/dynamic/datasource/support/HealthCheckAdapter.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/support/HealthCheckAdapter.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2018 organization baomidou
+ * <pre>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <pre/>
+ */
+package com.baomidou.dynamic.datasource.support;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author ls9527
+ */
+public class HealthCheckAdapter {
+
+    /**
+     * 维护数据源健康状况
+     */
+    private static final Map<String, Boolean> DB_HEALTH = new ConcurrentHashMap<>();
+
+
+    public void putHealth(String key, Boolean healthState) {
+        DB_HEALTH.put(key,healthState);
+    }
+
+    /**
+     * 获取数据源连接健康状况
+     *
+     * @param dataSource 数据源名称
+     * @return 健康状况
+     */
+    public boolean getHealth(String dataSource) {
+        Boolean isHealth = DB_HEALTH.get(dataSource);
+        return isHealth != null && isHealth;
+    }
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/toolkit/DynamicDataSourceContextHolder.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/toolkit/DynamicDataSourceContextHolder.java
@@ -65,8 +65,10 @@ public final class DynamicDataSourceContextHolder {
      *
      * @param ds 数据源名称
      */
-    public static void push(String ds) {
-        LOOKUP_KEY_HOLDER.get().push(StringUtils.isEmpty(ds) ? "" : ds);
+    public static String push(String ds) {
+        String dataSourceStr = StringUtils.isEmpty(ds) ? "" : ds;
+        LOOKUP_KEY_HOLDER.get().push(dataSourceStr);
+        return dataSourceStr;
     }
 
     /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
主从分离修复mp兼容。
主从分离的查询方式增加6个参数的查询， 当启用 mybatis-plus 的分页查询插件时， 会调用 simpleExecutor 的6个参数的查询

优化健康检查的配置和选择方式。
启用健康检查时  
1. 从库健康，可选从库， 从库不健康，打印日志，并选择主库
2. 主库无论如何都可以被选择, 即使主库的健康检查是失败的

**Other information:**



