### PR TITLE
fix: Fix the DynamicDataSourceContextHolder wrong operation if an exc…

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicDataSourceAnnotationInterceptor.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicDataSourceAnnotationInterceptor.java
@@ -45,9 +45,9 @@ public class DynamicDataSourceAnnotationInterceptor implements MethodInterceptor
 
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
+        String dsKey = determineDatasourceKey(invocation);
+        DynamicDataSourceContextHolder.push(dsKey);
         try {
-            String dsKey = determineDatasourceKey(invocation);
-            DynamicDataSourceContextHolder.push(dsKey);
             return invocation.proceed();
         } finally {
             DynamicDataSourceContextHolder.poll();


### PR DESCRIPTION
…eption happened in the data source key determining

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
If an exception occurs during the processing of the dsKey, the dsKey will not push into DynamicDataSourceContextHolder, but the finally block will still be executed.
Move dsKey determine and push outside the try block.

**Other information:**
