### PR TITLE
调整DataSourceCreator默认顺序访问级别

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceCreatorAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceCreatorAutoConfiguration.java
@@ -40,10 +40,10 @@ import java.util.List;
 @EnableConfigurationProperties(DynamicDataSourceProperties.class)
 public class DynamicDataSourceCreatorAutoConfiguration {
 
-    private static final int JNDI_ORDER = 1000;
-    private static final int DRUID_ORDER = 2000;
-    private static final int HIKARI_ORDER = 3000;
-    private static final int DEFAULT_ORDER = 5000;
+    public static final int JNDI_ORDER = 1000;
+    public static final int DRUID_ORDER = 2000;
+    public static final int HIKARI_ORDER = 3000;
+    public static final int DEFAULT_ORDER = 5000;
     private final DynamicDataSourceProperties properties;
 
     @Primary


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
自定义DruidDataSourceCreator等时可沿用现有顺序，如下图所示

![Xnip2021-01-05_01-11-19](https://user-images.githubusercontent.com/3069117/103561038-cc81a500-4ef3-11eb-8223-ec1743596a1c.jpg)


**Other information:**



