### PR TITLE
fix: 修复spring.datasource.dynamic.druid.maxWait等配置未生效的问题

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/creator/DruidDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/DruidDataSourceCreator.java
@@ -203,6 +203,26 @@ public class DruidDataSourceCreator extends AbstractDataSourceCreator implements
         if (transactionQueryTimeout != null) {
             dataSource.setTransactionQueryTimeout(transactionQueryTimeout);
         }
+
+        Integer initialSize = config.getInitialSize() == null ? gConfig.getInitialSize() : config.getInitialSize();
+        if (initialSize != null) {
+            dataSource.setInitialSize(initialSize);
+        }
+
+        Integer minIdle = config.getMinIdle() == null ? gConfig.getMinIdle() : config.getMinIdle();
+        if (minIdle != null) {
+            dataSource.setMinIdle(minIdle);
+        }
+
+        Integer maxActive = config.getMaxActive() == null ? gConfig.getMaxActive() : config.getMaxActive();
+        if (maxActive != null) {
+            dataSource.setMaxActive(maxActive);
+        }
+
+        Integer maxWait = config.getMaxWait() == null ? gConfig.getMaxWait() : config.getMaxWait();
+        if (maxWait != null) {
+            dataSource.setMaxWait(maxWait);
+        }
     }
 
     @Override


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
修复一些连接池配置未生效的问题
比如spring.datasource.dynamic.druid.maxWait, spring.datasource.dynamic.druid.maxActive等
曾导致maxWait使用了默认值 -1 ，数据库连接卡住，无任何响应

**Other information:**



