### PR TITLE
多数据源时通过子类决定事物管理器 👉 #3199

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -26,6 +26,7 @@ import com.baomidou.dynamic.datasource.processor.DsSpelExpressionProcessor;
 import com.baomidou.dynamic.datasource.provider.DynamicDataSourceProvider;
 import com.baomidou.dynamic.datasource.provider.YmlDynamicDataSourceProvider;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidDynamicDataSourceConfiguration;
+import com.baomidou.dynamic.datasource.spring.ext.AnnotationTransactionAttributeSourceReplacer;
 import com.baomidou.dynamic.datasource.strategy.DynamicDataSourceStrategy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.Advisor;
@@ -127,6 +128,12 @@ public class DynamicDataSourceAutoConfiguration implements InitializingBean {
         headerProcessor.setNextProcessor(sessionProcessor);
         sessionProcessor.setNextProcessor(spelExpressionProcessor);
         return headerProcessor;
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = DynamicDataSourceProperties.PREFIX, name = "assignTm", havingValue = "false")
+    public AnnotationTransactionAttributeSourceReplacer attributeSourceReplacer() {
+        return new AnnotationTransactionAttributeSourceReplacer();
     }
 
     @Override

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -26,7 +26,6 @@ import com.baomidou.dynamic.datasource.processor.DsSpelExpressionProcessor;
 import com.baomidou.dynamic.datasource.provider.DynamicDataSourceProvider;
 import com.baomidou.dynamic.datasource.provider.YmlDynamicDataSourceProvider;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidDynamicDataSourceConfiguration;
-import com.baomidou.dynamic.datasource.spring.ext.AnnotationTransactionAttributeSourceReplacer;
 import com.baomidou.dynamic.datasource.strategy.DynamicDataSourceStrategy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.Advisor;
@@ -128,12 +127,6 @@ public class DynamicDataSourceAutoConfiguration implements InitializingBean {
         headerProcessor.setNextProcessor(sessionProcessor);
         sessionProcessor.setNextProcessor(spelExpressionProcessor);
         return headerProcessor;
-    }
-
-    @Bean
-    @ConditionalOnProperty(prefix = DynamicDataSourceProperties.PREFIX, name = "assignTm", havingValue = "false")
-    public AnnotationTransactionAttributeSourceReplacer attributeSourceReplacer() {
-        return new AnnotationTransactionAttributeSourceReplacer();
     }
 
     @Override

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
@@ -123,4 +123,9 @@ public class DynamicDataSourceProperties {
      * aop 切面是否只允许切 public 方法
      */
     private boolean allowedPublicOnly = true;
+
+    /**
+     * 是否开启指定事物管理器，默认 {@code false}
+     */
+    private boolean assignTm = false;
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/TransactionManagerDeterminerAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/TransactionManagerDeterminerAutoConfiguration.java
@@ -1,0 +1,19 @@
+package com.baomidou.dynamic.datasource.spring.boot.autoconfigure;
+
+import com.baomidou.dynamic.datasource.spring.ext.AnnotationTransactionAttributeSourceReplacer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author dyu 2021/7/2 11:30
+ */
+@Configuration
+@ConditionalOnProperty(prefix = DynamicDataSourceProperties.PREFIX, name = "assignTm", havingValue = "true")
+public class TransactionManagerDeterminerAutoConfiguration {
+
+    @Bean
+    public AnnotationTransactionAttributeSourceReplacer attributeSourceReplacer() {
+        return new AnnotationTransactionAttributeSourceReplacer();
+    }
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/ext/AnnotationTransactionAttributeSourceReplacer.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/ext/AnnotationTransactionAttributeSourceReplacer.java
@@ -33,17 +33,17 @@ public class AnnotationTransactionAttributeSourceReplacer implements Instantiati
 
     @Override
     public PropertyValues postProcessPropertyValues(PropertyValues propertyValues, PropertyDescriptor[] propertyDescriptors, Object o, String s) throws BeansException {
-        return null;
+        return propertyValues;
     }
 
     @Override
     public Object postProcessBeforeInitialization(Object o, String s) throws BeansException {
-        return null;
+        return o;
     }
 
     @Override
     public Object postProcessAfterInitialization(Object o, String s) throws BeansException {
-        return null;
+        return o;
     }
 
     @Override

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/ext/AnnotationTransactionAttributeSourceReplacer.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/ext/AnnotationTransactionAttributeSourceReplacer.java
@@ -1,13 +1,10 @@
 package com.baomidou.dynamic.datasource.spring.ext;
 
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.PropertyValues;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessor;
 import org.springframework.core.PriorityOrdered;
-import org.springframework.stereotype.Component;
 import org.springframework.transaction.interceptor.TransactionAttributeSource;
 
 import java.beans.PropertyDescriptor;
@@ -16,20 +13,10 @@ import java.beans.PropertyDescriptor;
  * @author dyu 2021/6/3 19:28
  */
 @Slf4j
-@Component
 public class AnnotationTransactionAttributeSourceReplacer implements InstantiationAwareBeanPostProcessor, PriorityOrdered {
-
-    private final DynamicDataSourceProperties dynamicDataSourceProperties;
-
-    public AnnotationTransactionAttributeSourceReplacer(DynamicDataSourceProperties dynamicDataSourceProperties) {
-        this.dynamicDataSourceProperties = dynamicDataSourceProperties;
-    }
 
     @Override
     public Object postProcessBeforeInstantiation(Class<?> aClass, String s) throws BeansException {
-        if (!dynamicDataSourceProperties.isAssignTm()) {
-            return null;
-        }
         log.trace(String.format("postProcessBeforeInstantiation - beanName: {%s}, beanClass: {%s})", s, aClass));
         if (s.equals("transactionAttributeSource") && TransactionAttributeSource.class.isAssignableFrom(aClass)) {
             log.debug("instantiating bean {} as {}", s, MergeAnnotationTransactionAttributeSource.class.getName());

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/ext/AnnotationTransactionAttributeSourceReplacer.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/ext/AnnotationTransactionAttributeSourceReplacer.java
@@ -1,0 +1,66 @@
+package com.baomidou.dynamic.datasource.spring.ext;
+
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.PropertyValues;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessor;
+import org.springframework.core.PriorityOrdered;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.interceptor.TransactionAttributeSource;
+
+import java.beans.PropertyDescriptor;
+
+/**
+ * @author dyu 2021/6/3 19:28
+ */
+@Slf4j
+@Component
+public class AnnotationTransactionAttributeSourceReplacer implements InstantiationAwareBeanPostProcessor, PriorityOrdered {
+
+    private final DynamicDataSourceProperties dynamicDataSourceProperties;
+
+    public AnnotationTransactionAttributeSourceReplacer(DynamicDataSourceProperties dynamicDataSourceProperties) {
+        this.dynamicDataSourceProperties = dynamicDataSourceProperties;
+    }
+
+    @Override
+    public Object postProcessBeforeInstantiation(Class<?> aClass, String s) throws BeansException {
+        if (!dynamicDataSourceProperties.isAssignTm()) {
+            return null;
+        }
+        log.trace(String.format("postProcessBeforeInstantiation - beanName: {%s}, beanClass: {%s})", s, aClass));
+        if (s.equals("transactionAttributeSource") && TransactionAttributeSource.class.isAssignableFrom(aClass)) {
+            log.debug("instantiating bean {} as {}", s, MergeAnnotationTransactionAttributeSource.class.getName());
+            return new MergeAnnotationTransactionAttributeSource();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean postProcessAfterInstantiation(Object o, String s) throws BeansException {
+        return true;
+    }
+
+    @Override
+    public PropertyValues postProcessPropertyValues(PropertyValues propertyValues, PropertyDescriptor[] propertyDescriptors, Object o, String s) throws BeansException {
+        return null;
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object o, String s) throws BeansException {
+        return null;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object o, String s) throws BeansException {
+        return null;
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/ext/MergeAnnotationTransactionAttributeSource.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/ext/MergeAnnotationTransactionAttributeSource.java
@@ -1,0 +1,118 @@
+package com.baomidou.dynamic.datasource.spring.ext;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute;
+import org.springframework.transaction.interceptor.TransactionAttribute;
+import org.springframework.util.ClassUtils;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ * @author dyu 2021/6/3 19:42
+ */
+@Slf4j
+public class MergeAnnotationTransactionAttributeSource extends AnnotationTransactionAttributeSource {
+
+    private static final long serialVersionUID = 8681456075483384142L;
+
+    @Override
+    @Nullable
+    protected TransactionAttribute computeTransactionAttribute(Method method, @Nullable Class<?> targetClass) {
+        // 方法必须是PUBLIC修饰的
+        if (allowPublicMethodsOnly() && !Modifier.isPublic(method.getModifiers())) {
+            return null;
+        }
+
+        // 如果方法未实现，则会从目标类获取属性
+        // 如果目标类为NULL,方法保持不变
+        Method specificMethod = AopUtils.getMostSpecificMethod(method, targetClass);
+
+        // 第一优先级取具体方法上的属性
+        TransactionAttribute txAttr = findTransactionAttribute(specificMethod);
+
+        // 第二优先级取具体方法对应类上的属性
+        Class<?> declaringClass = specificMethod.getDeclaringClass();
+        boolean userLevelMethod = ClassUtils.isUserLevelMethod(method);
+        if (userLevelMethod) {
+            txAttr = merge(txAttr, findTransactionAttribute(declaringClass));
+        }
+
+        // 第三优先级是目标类上的属性
+        if (targetClass != null && !targetClass.equals(declaringClass) && userLevelMethod) {
+            txAttr = merge(txAttr, findTransactionAttribute(targetClass));
+        }
+
+        if (method != specificMethod) {
+            // 第四优先级取声明的类或者接口的方法上的属性
+            txAttr = merge(txAttr, findTransactionAttribute(method));
+
+            // 第五优先级取声明的类或者接口上的属性
+            txAttr = merge(txAttr, findTransactionAttribute(method.getDeclaringClass()));
+        }
+
+        return txAttr;
+    }
+
+    /**
+     * 设置“次要”对象中“主要”对象的空属性和默认属性
+     * <p>调用该方法后不要使用参数，存在修改</p>
+     */
+    @Nullable
+    private TransactionAttribute merge(@Nullable TransactionAttribute primaryObj, @Nullable TransactionAttribute secondaryObj) {
+        if (primaryObj == null) {
+            return secondaryObj;
+        }
+        if (secondaryObj == null) {
+            return primaryObj;
+        }
+
+        if (primaryObj instanceof DefaultTransactionAttribute && secondaryObj instanceof DefaultTransactionAttribute) {
+            DefaultTransactionAttribute primary = (DefaultTransactionAttribute) primaryObj;
+            DefaultTransactionAttribute secondary = (DefaultTransactionAttribute) secondaryObj;
+
+            if (primary.getQualifier() == null || primary.getQualifier().isEmpty()) {
+                primary.setQualifier(secondary.getQualifier());
+            }
+            if (primary.getDescriptor() == null || primary.getDescriptor().isEmpty()) {
+                primary.setDescriptor(secondary.getDescriptor());
+            }
+            if (primary.getName() == null || primary.getName().isEmpty()) {
+                primary.setName(secondary.getName());
+            }
+
+            // The following properties have default values in DefaultTransactionDefinition;
+            // we cannot distinguish here, whether these values have been set explicitly or implicitly;
+            // but it seems to be logical to handle default values like empty values.
+            if (primary.getPropagationBehavior() == TransactionDefinition.PROPAGATION_REQUIRED) {
+                primary.setPropagationBehavior(secondary.getPropagationBehavior());
+            }
+            if (primary.getIsolationLevel() == TransactionDefinition.ISOLATION_DEFAULT) {
+                primary.setIsolationLevel(secondary.getIsolationLevel());
+            }
+            if (primary.getTimeout() == TransactionDefinition.TIMEOUT_DEFAULT) {
+                primary.setTimeout(secondary.getTimeout());
+            }
+            if (!primary.isReadOnly()) {
+                primary.setReadOnly(secondary.isReadOnly());
+            }
+        }
+
+        if (primaryObj instanceof RuleBasedTransactionAttribute && secondaryObj instanceof RuleBasedTransactionAttribute) {
+            RuleBasedTransactionAttribute primary = (RuleBasedTransactionAttribute) primaryObj;
+            RuleBasedTransactionAttribute secondary = (RuleBasedTransactionAttribute) secondaryObj;
+
+            if (primary.getRollbackRules().isEmpty()) {
+                primary.setRollbackRules(secondary.getRollbackRules());
+            }
+        }
+
+        return primaryObj;
+    }
+
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceAutoConfiguration
+com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceAutoConfiguration,\
+com.baomidou.dynamic.datasource.spring.boot.autoconfigure.TransactionManagerDeterminerAutoConfiguration


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
[https://github.com/baomidou/mybatis-plus/pull/3199#issue-544082283](url)看这

**Other information:**
主要针对多数据源时，mp的service的接口上的spring事物注解无法选择准确的事物管理器导致的问题，通过开关的形式决定是否加载
