### PR TITLE
调整DsProcessor处理逻辑

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicDataSourceAnnotationInterceptor.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicDataSourceAnnotationInterceptor.java
@@ -15,9 +15,10 @@
  */
 package com.baomidou.dynamic.datasource.aop;
 
-import com.baomidou.dynamic.datasource.processor.DsProcessor;
+import com.baomidou.dynamic.datasource.processor.DsProcessorHandler;
 import com.baomidou.dynamic.datasource.support.DataSourceClassResolver;
 import com.baomidou.dynamic.datasource.toolkit.DynamicDataSourceContextHolder;
+
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
@@ -25,6 +26,7 @@ import org.aopalliance.intercept.MethodInvocation;
  * Core Interceptor of Dynamic Datasource
  *
  * @author TaoYu
+ * @author nukiyoam
  * @since 1.2.0
  */
 public class DynamicDataSourceAnnotationInterceptor implements MethodInterceptor {
@@ -35,11 +37,12 @@ public class DynamicDataSourceAnnotationInterceptor implements MethodInterceptor
     private static final String DYNAMIC_PREFIX = "#";
 
     private final DataSourceClassResolver dataSourceClassResolver;
-    private final DsProcessor dsProcessor;
 
-    public DynamicDataSourceAnnotationInterceptor(Boolean allowedPublicOnly, DsProcessor dsProcessor) {
+    private final DsProcessorHandler dsProcessorHandler;
+
+    public DynamicDataSourceAnnotationInterceptor(Boolean allowedPublicOnly, DsProcessorHandler dsProcessorHandler) {
         dataSourceClassResolver = new DataSourceClassResolver(allowedPublicOnly);
-        this.dsProcessor = dsProcessor;
+        this.dsProcessorHandler = dsProcessorHandler;
     }
 
     @Override
@@ -55,6 +58,6 @@ public class DynamicDataSourceAnnotationInterceptor implements MethodInterceptor
 
     private String determineDatasourceKey(MethodInvocation invocation) {
         String key = dataSourceClassResolver.findDSKey(invocation.getMethod(), invocation.getThis());
-        return (!key.isEmpty() && key.startsWith(DYNAMIC_PREFIX)) ? dsProcessor.determineDatasource(invocation, key) : key;
+        return (!key.isEmpty() && key.startsWith(DYNAMIC_PREFIX)) ? dsProcessorHandler.determineDatasource(invocation, key) : key;
     }
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicDatasourceNamedInterceptor.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicDatasourceNamedInterceptor.java
@@ -16,26 +16,30 @@
 package com.baomidou.dynamic.datasource.aop;
 
 
-import com.baomidou.dynamic.datasource.processor.DsProcessor;
-import com.baomidou.dynamic.datasource.toolkit.DynamicDataSourceContextHolder;
-import lombok.extern.slf4j.Slf4j;
-import org.aopalliance.intercept.MethodInterceptor;
-import org.aopalliance.intercept.MethodInvocation;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.PatternMatchUtils;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.lang.reflect.Method;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.baomidou.dynamic.datasource.processor.DsProcessorHandler;
+import com.baomidou.dynamic.datasource.toolkit.DynamicDataSourceContextHolder;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.PatternMatchUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Named Interceptor of Dynamic Datasource
  *
  * @author TaoYu
+ * @author nukiyoam
  * @since 3.4.0
  */
 @Slf4j
@@ -43,10 +47,11 @@ public class DynamicDatasourceNamedInterceptor implements MethodInterceptor {
 
     private static final String DYNAMIC_PREFIX = "#";
     private final Map<String, String> nameMap = new HashMap<>();
-    private final DsProcessor dsProcessor;
 
-    public DynamicDatasourceNamedInterceptor(DsProcessor dsProcessor) {
-        this.dsProcessor = dsProcessor;
+    private final DsProcessorHandler dsProcessorHandler;
+
+    public DynamicDatasourceNamedInterceptor(DsProcessorHandler dsProcessorHandler) {
+        this.dsProcessorHandler = dsProcessorHandler;
     }
 
     @Nullable
@@ -111,7 +116,7 @@ public class DynamicDatasourceNamedInterceptor implements MethodInterceptor {
 
     private String determineDatasourceKey(MethodInvocation invocation) {
         String key = findDsKey(invocation);
-        return (key != null && key.startsWith(DYNAMIC_PREFIX)) ? dsProcessor.determineDatasource(invocation, key) : key;
+        return (key != null && key.startsWith(DYNAMIC_PREFIX)) ? dsProcessorHandler.determineDatasource(invocation, key) : key;
     }
 
     private String findDsKey(MethodInvocation invocation) {

--- a/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicLocalTransactionAdvisor.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicLocalTransactionAdvisor.java
@@ -15,19 +15,18 @@
  */
 package com.baomidou.dynamic.datasource.aop;
 
+import java.util.UUID;
+
 import com.baomidou.dynamic.datasource.tx.ConnectionFactory;
 import com.baomidou.dynamic.datasource.tx.TransactionContext;
-import lombok.extern.slf4j.Slf4j;
+
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.util.StringUtils;
 
-import java.util.UUID;
-
 /**
  * @author funkye
  */
-@Slf4j
 public class DynamicLocalTransactionAdvisor implements MethodInterceptor {
 
     @Override

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/BasicDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/BasicDataSourceCreator.java
@@ -15,12 +15,14 @@
  */
 package com.baomidou.dynamic.datasource.creator;
 
-import com.baomidou.dynamic.datasource.exception.ErrorCreateDataSourceException;
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
-import lombok.extern.slf4j.Slf4j;
+import java.lang.reflect.Method;
 
 import javax.sql.DataSource;
-import java.lang.reflect.Method;
+
+import com.baomidou.dynamic.datasource.exception.ErrorCreateDataSourceException;
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 基础数据源创建器
@@ -29,7 +31,7 @@ import java.lang.reflect.Method;
  * @since 2020/1/21
  */
 @Slf4j
-public class BasicDataSourceCreator extends AbstractDataSourceCreator implements DataSourceCreator {
+public class BasicDataSourceCreator extends AbstractDataSourceCreator {
 
     private static Method createMethod;
     private static Method typeMethod;

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/BeeCpDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/BeeCpDataSourceCreator.java
@@ -15,20 +15,22 @@
  */
 package com.baomidou.dynamic.datasource.creator;
 
-import cn.beecp.BeeDataSource;
-import cn.beecp.BeeDataSourceConfig;
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.beecp.BeeCpConfig;
-import com.baomidou.dynamic.datasource.toolkit.ConfigMergeCreator;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.util.StringUtils;
+import static com.baomidou.dynamic.datasource.support.DdConstants.BEECP_DATASOURCE;
 
-import javax.sql.DataSource;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import static com.baomidou.dynamic.datasource.support.DdConstants.BEECP_DATASOURCE;
+import javax.sql.DataSource;
+
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.beecp.BeeCpConfig;
+import com.baomidou.dynamic.datasource.toolkit.ConfigMergeCreator;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.StringUtils;
+
+import cn.beecp.BeeDataSource;
+import cn.beecp.BeeDataSourceConfig;
 
 /**
  * BeeCp数据源创建器
@@ -36,8 +38,7 @@ import static com.baomidou.dynamic.datasource.support.DdConstants.BEECP_DATASOUR
  * @author TaoYu
  * @since 2020/5/14
  */
-@Slf4j
-public class BeeCpDataSourceCreator extends AbstractDataSourceCreator implements DataSourceCreator, InitializingBean {
+public class BeeCpDataSourceCreator extends AbstractDataSourceCreator implements InitializingBean {
 
     private static final ConfigMergeCreator<BeeCpConfig, BeeDataSourceConfig> MERGE_CREATOR = new ConfigMergeCreator<>("BeeCp", BeeCpConfig.class, BeeDataSourceConfig.class);
 

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/Dbcp2DataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/Dbcp2DataSourceCreator.java
@@ -15,17 +15,19 @@
  */
 package com.baomidou.dynamic.datasource.creator;
 
+import static com.baomidou.dynamic.datasource.support.DdConstants.DBCP2_DATASOURCE;
+
+import javax.sql.DataSource;
+
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.dbcp2.Dbcp2Config;
 import com.baomidou.dynamic.datasource.toolkit.ConfigMergeCreator;
-import lombok.SneakyThrows;
+
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.StringUtils;
 
-import javax.sql.DataSource;
-
-import static com.baomidou.dynamic.datasource.support.DdConstants.DBCP2_DATASOURCE;
+import lombok.SneakyThrows;
 
 /**
  * DBCP数据源创建器
@@ -33,7 +35,7 @@ import static com.baomidou.dynamic.datasource.support.DdConstants.DBCP2_DATASOUR
  * @author TaoYu
  * @since 2021/5/18
  */
-public class Dbcp2DataSourceCreator extends AbstractDataSourceCreator implements DataSourceCreator, InitializingBean {
+public class Dbcp2DataSourceCreator extends AbstractDataSourceCreator implements InitializingBean {
 
     private static final ConfigMergeCreator<Dbcp2Config, BasicDataSource> MERGE_CREATOR = new ConfigMergeCreator<>("Dbcp2", Dbcp2Config.class, BasicDataSource.class);
 

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/DefaultDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/DefaultDataSourceCreator.java
@@ -15,12 +15,13 @@
  */
 package com.baomidou.dynamic.datasource.creator;
 
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
 
 import javax.sql.DataSource;
-import java.util.List;
+
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+
+import lombok.Setter;
 
 /**
  * 数据源创建器
@@ -28,7 +29,6 @@ import java.util.List;
  * @author TaoYu
  * @since 2.3.0
  */
-@Slf4j
 @Setter
 public class DefaultDataSourceCreator {
 

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/DruidDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/DruidDataSourceCreator.java
@@ -15,6 +15,15 @@
  */
 package com.baomidou.dynamic.datasource.creator;
 
+import static com.baomidou.dynamic.datasource.support.DdConstants.DRUID_DATASOURCE;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import javax.sql.DataSource;
+
 import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.filter.logging.Slf4jLogFilter;
 import com.alibaba.druid.filter.stat.StatFilter;
@@ -26,18 +35,11 @@ import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourcePrope
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConfig;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidSlf4jConfig;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidWallConfigUtil;
+
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.util.StringUtils;
-
-import javax.sql.DataSource;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-
-import static com.baomidou.dynamic.datasource.support.DdConstants.DRUID_DATASOURCE;
 
 /**
  * Druid数据源创建器
@@ -45,7 +47,7 @@ import static com.baomidou.dynamic.datasource.support.DdConstants.DRUID_DATASOUR
  * @author TaoYu
  * @since 2020/1/21
  */
-public class DruidDataSourceCreator extends AbstractDataSourceCreator implements DataSourceCreator, InitializingBean {
+public class DruidDataSourceCreator extends AbstractDataSourceCreator implements InitializingBean {
 
     @Autowired(required = false)
     private ApplicationContext applicationContext;

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/HikariDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/HikariDataSourceCreator.java
@@ -15,19 +15,21 @@
  */
 package com.baomidou.dynamic.datasource.creator;
 
+import static com.baomidou.dynamic.datasource.support.DdConstants.HIKARI_DATASOURCE;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.sql.DataSource;
+
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.hikari.HikariCpConfig;
 import com.baomidou.dynamic.datasource.toolkit.ConfigMergeCreator;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.StringUtils;
-
-import javax.sql.DataSource;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
-import static com.baomidou.dynamic.datasource.support.DdConstants.HIKARI_DATASOURCE;
 
 /**
  * Hikari数据源创建器
@@ -35,7 +37,7 @@ import static com.baomidou.dynamic.datasource.support.DdConstants.HIKARI_DATASOU
  * @author TaoYu
  * @since 2020/1/21
  */
-public class HikariDataSourceCreator extends AbstractDataSourceCreator implements DataSourceCreator, InitializingBean {
+public class HikariDataSourceCreator extends AbstractDataSourceCreator implements InitializingBean {
 
     private static final ConfigMergeCreator<HikariCpConfig, HikariConfig> MERGE_CREATOR = new ConfigMergeCreator<>("HikariCp", HikariCpConfig.class, HikariConfig.class);
     private static Method configCopyMethod = null;

--- a/src/main/java/com/baomidou/dynamic/datasource/creator/JndiDataSourceCreator.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/creator/JndiDataSourceCreator.java
@@ -15,10 +15,11 @@
  */
 package com.baomidou.dynamic.datasource.creator;
 
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
-import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
-
 import javax.sql.DataSource;
+
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+
+import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
 
 /**
  * JNDI数据源创建器
@@ -26,7 +27,7 @@ import javax.sql.DataSource;
  * @author TaoYu
  * @since 2020/1/27
  */
-public class JndiDataSourceCreator extends AbstractDataSourceCreator implements DataSourceCreator {
+public class JndiDataSourceCreator extends AbstractDataSourceCreator {
 
     private static final JndiDataSourceLookup LOOKUP = new JndiDataSourceLookup();
 

--- a/src/main/java/com/baomidou/dynamic/datasource/exception/CannotFoundDsProcessorException.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/exception/CannotFoundDsProcessorException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2018 organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.dynamic.datasource.exception;
+
+/**
+ * exception when DsProcessor not found
+ *
+ * @author nukiyoam
+ */
+public class CannotFoundDsProcessorException extends RuntimeException {
+
+    public CannotFoundDsProcessorException(String message) {
+        super(message);
+    }
+
+    public CannotFoundDsProcessorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/plugin/MasterSlaveAutoRoutingPlugin.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/plugin/MasterSlaveAutoRoutingPlugin.java
@@ -15,21 +15,26 @@
  */
 package com.baomidou.dynamic.datasource.plugin;
 
+import java.util.Properties;
+
+import javax.sql.DataSource;
+
 import com.baomidou.dynamic.datasource.support.DdConstants;
 import com.baomidou.dynamic.datasource.toolkit.DynamicDataSourceContextHolder;
-import lombok.extern.slf4j.Slf4j;
+
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.mapping.SqlCommandType;
-import org.apache.ibatis.plugin.*;
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.plugin.Intercepts;
+import org.apache.ibatis.plugin.Invocation;
+import org.apache.ibatis.plugin.Plugin;
+import org.apache.ibatis.plugin.Signature;
 import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import javax.sql.DataSource;
-import java.util.Properties;
 
 /**
  * Master-slave Separation Plugin with mybatis
@@ -41,7 +46,6 @@ import java.util.Properties;
         @Signature(type = Executor.class, method = "query", args = {MappedStatement.class, Object.class, RowBounds.class, ResultHandler.class}),
         @Signature(type = Executor.class, method = "query", args = {MappedStatement.class, Object.class, RowBounds.class, ResultHandler.class, CacheKey.class, BoundSql.class}),
         @Signature(type = Executor.class, method = "update", args = {MappedStatement.class, Object.class})})
-@Slf4j
 public class MasterSlaveAutoRoutingPlugin implements Interceptor {
 
     @Autowired

--- a/src/main/java/com/baomidou/dynamic/datasource/processor/DsProcessor.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/processor/DsProcessor.java
@@ -19,54 +19,27 @@ import org.aopalliance.intercept.MethodInvocation;
 
 /**
  * @author TaoYu
+ * @author nukiyoam
  * @since 2.5.0
  */
 public abstract class DsProcessor {
 
-    private DsProcessor nextProcessor;
-
-    public void setNextProcessor(DsProcessor dsProcessor) {
-        this.nextProcessor = dsProcessor;
-    }
-
     /**
      * 抽象匹配条件 匹配才会走当前执行器否则走下一级执行器
      *
-     * @param key DS注解里的内容
+     * @param key
+     *            DS注解里的内容
      * @return 是否匹配
      */
     public abstract boolean matches(String key);
 
     /**
-     * 决定数据源
-     * <pre>
-     *     调用底层doDetermineDatasource，
-     *     如果返回的是null则继续执行下一个，否则直接返回
-     * </pre>
-     *
-     * @param invocation 方法执行信息
-     * @param key        DS注解里的内容
-     * @return 数据源名称
-     */
-    public String determineDatasource(MethodInvocation invocation, String key) {
-        if (matches(key)) {
-            String datasource = doDetermineDatasource(invocation, key);
-            if (datasource == null && nextProcessor != null) {
-                return nextProcessor.determineDatasource(invocation, key);
-            }
-            return datasource;
-        }
-        if (nextProcessor != null) {
-            return nextProcessor.determineDatasource(invocation, key);
-        }
-        return null;
-    }
-
-    /**
      * 抽象最终决定数据源
      *
-     * @param invocation 方法执行信息
-     * @param key        DS注解里的内容
+     * @param invocation
+     *            方法执行信息
+     * @param key
+     *            DS注解里的内容
      * @return 数据源名称
      */
     public abstract String doDetermineDatasource(MethodInvocation invocation, String key);

--- a/src/main/java/com/baomidou/dynamic/datasource/processor/DsProcessor.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/processor/DsProcessor.java
@@ -18,8 +18,29 @@ package com.baomidou.dynamic.datasource.processor;
 import org.aopalliance.intercept.MethodInvocation;
 
 /**
+ * 需要拓展processor，可在配置类中配置
+ * 
+ * <p>
+ * 
+ * <pre>
+ * 
+ * public class FooDsProcessor extends DsProcessor {} 
+ * 
+ * 
+ * @Configuration
+ * public class FooConfig {
+ * 
+ *     @Bean
+ *     public DsProcessor fooDsProcessor() {
+ *         return new FooDsProcessor();
+ *     }
+ *      
+ * }
+ * </pre>
+ * 
  * @author TaoYu
  * @author nukiyoam
+ * @see DsProcessorHandler
  * @since 2.5.0
  */
 public abstract class DsProcessor {

--- a/src/main/java/com/baomidou/dynamic/datasource/processor/DsProcessorHandler.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/processor/DsProcessorHandler.java
@@ -18,12 +18,12 @@ package com.baomidou.dynamic.datasource.processor;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.baomidou.dynamic.datasource.exception.CannotFindDataSourceException;
 import com.baomidou.dynamic.datasource.exception.CannotFoundDsProcessorException;
 import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -44,7 +44,7 @@ public class DsProcessorHandler {
     /**
      * 统一管理所有的processor
      */
-    @Autowired
+    @Autowired(required = false)
     private List<DsProcessor> processors = new ArrayList<>();
 
     /**
@@ -99,18 +99,13 @@ public class DsProcessorHandler {
                 log.info("mathed processor [{}] for key [{}]", dsProcessor.getClass(), key);
                 matchedProcessor = true;
                 datasource = dsProcessor.doDetermineDatasource(invocation, key);
-                if (datasource != null) {
+                if (StringUtils.hasText(datasource)) {
                     break;
-                } else {
-                    return dsProcessor.doDetermineDatasource(invocation, key);
                 }
             }
         }
         if (!matchedProcessor) {
             throw new CannotFoundDsProcessorException("cant not found any ds processor for key: " + key);
-        }
-        if (datasource == null || datasource.length() == 0) {
-            throw new CannotFindDataSourceException("the datasource is null or empty for key: " + key);
         }
         return datasource;
     }

--- a/src/main/java/com/baomidou/dynamic/datasource/processor/DsProcessorHandler.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/processor/DsProcessorHandler.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2018 organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.dynamic.datasource.processor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.baomidou.dynamic.datasource.exception.CannotFindDataSourceException;
+import com.baomidou.dynamic.datasource.exception.CannotFoundDsProcessorException;
+import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * ds processor 容器
+ * 
+ * 将所有可用的processor统一管理
+ * 
+ * 拓展时可通过继承{@link DsProcessor}来实现不同的processor处理
+ * 
+ * 注意：拓展时继承{@link DsProcessor}的bean需要由spring容器管理
+ *
+ * @author nukiyoam
+ */
+@Slf4j
+public class DsProcessorHandler {
+
+    /**
+     * 统一管理所有的processor
+     */
+    @Autowired
+    private List<DsProcessor> processors = new ArrayList<>();
+
+    /**
+     * add processor to list
+     * 
+     * @param processor
+     *            processor
+     */
+    public void addProcessor(DsProcessor processor) {
+        if (processor == null) {
+            throw new IllegalArgumentException("add processor cant not be null");
+        }
+        this.processors.add(processor);
+    }
+
+    /**
+     * add processor to list
+     * 
+     * @param processors
+     *            one or more processor
+     */
+    public void addProcessor(DsProcessor... processors) {
+        if (processors == null || processors.length == 0) {
+            throw new IllegalArgumentException("add processor cant not be null or empty array");
+        }
+        for (DsProcessor dsProcessor : processors) {
+            this.addProcessor(dsProcessor);
+        }
+    }
+
+    /**
+     * 决定数据源
+     * 
+     * 将所有的processor挨个匹配，找到能够处理的processor
+     * 
+     * 如果所有processor都匹配完，还是没有找到，则抛出{@link CannotFoundDsProcessorException}异常
+     *
+     * @param invocation
+     *            方法执行信息
+     * @param key
+     *            DS注解里的内容
+     * @return 数据源名称
+     */
+    public String determineDatasource(MethodInvocation invocation, String key) {
+        if (CollectionUtils.isEmpty(this.processors)) {
+            throw new CannotFoundDsProcessorException("cant not found any ds processor");
+        }
+        String datasource = null;
+        boolean matchedProcessor = false;
+        for (DsProcessor dsProcessor : this.processors) {
+            if (dsProcessor.matches(key)) {
+                log.info("mathed processor [{}] for key [{}]", dsProcessor.getClass(), key);
+                matchedProcessor = true;
+                datasource = dsProcessor.doDetermineDatasource(invocation, key);
+                if (datasource != null) {
+                    break;
+                } else {
+                    return dsProcessor.doDetermineDatasource(invocation, key);
+                }
+            }
+        }
+        if (!matchedProcessor) {
+            throw new CannotFoundDsProcessorException("cant not found any ds processor for key: " + key);
+        }
+        if (datasource == null || datasource.length() == 0) {
+            throw new CannotFindDataSourceException("the datasource is null or empty for key: " + key);
+        }
+        return datasource;
+    }
+
+}

--- a/src/main/java/com/baomidou/dynamic/datasource/processor/DsSpelExpressionProcessor.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/processor/DsSpelExpressionProcessor.java
@@ -15,6 +15,8 @@
  */
 package com.baomidou.dynamic.datasource.processor;
 
+import java.lang.reflect.Method;
+
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.context.expression.MethodBasedEvaluationContext;
 import org.springframework.core.DefaultParameterNameDiscoverer;
@@ -25,13 +27,16 @@ import org.springframework.expression.ParserContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
-import java.lang.reflect.Method;
-
 /**
  * @author TaoYu
  * @since 2.5.0
  */
 public class DsSpelExpressionProcessor extends DsProcessor {
+
+    /**
+     * spel 开头
+     */
+    private static final String SPEL_PREFIX = "#spel";
 
     /**
      * 参数发现器
@@ -64,11 +69,12 @@ public class DsSpelExpressionProcessor extends DsProcessor {
             return null;
         }
     };
+
     private BeanResolver beanResolver;
 
     @Override
     public boolean matches(String key) {
-        return true;
+        return key.startsWith(SPEL_PREFIX);
     }
 
     @Override
@@ -77,7 +83,7 @@ public class DsSpelExpressionProcessor extends DsProcessor {
         Object[] arguments = invocation.getArguments();
         StandardEvaluationContext context = new MethodBasedEvaluationContext(null, method, arguments, NAME_DISCOVERER);
         context.setBeanResolver(beanResolver);
-        final Object value = PARSER.parseExpression(key, parserContext).getValue(context);
+        final Object value = PARSER.parseExpression(key.substring(6), parserContext).getValue(context);
         return value == null ? null : value.toString();
     }
 

--- a/src/main/java/com/baomidou/dynamic/datasource/provider/AbstractDataSourceProvider.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/provider/AbstractDataSourceProvider.java
@@ -15,17 +15,17 @@
  */
 package com.baomidou.dynamic.datasource.provider;
 
-import com.baomidou.dynamic.datasource.creator.DefaultDataSourceCreator;
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import javax.sql.DataSource;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.sql.DataSource;
 
-@Slf4j
+import com.baomidou.dynamic.datasource.creator.DefaultDataSourceCreator;
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+
 public abstract class AbstractDataSourceProvider implements DynamicDataSourceProvider {
 
     @Autowired

--- a/src/main/java/com/baomidou/dynamic/datasource/provider/AbstractJdbcDataSourceProvider.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/provider/AbstractJdbcDataSourceProvider.java
@@ -15,17 +15,20 @@
  */
 package com.baomidou.dynamic.datasource.provider;
 
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.jdbc.support.JdbcUtils;
-import org.springframework.util.StringUtils;
-
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
+
+import javax.sql.DataSource;
+
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+
+import org.springframework.jdbc.support.JdbcUtils;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * JDBC数据源提供者(抽象)
@@ -34,7 +37,7 @@ import java.util.Map;
  * @since 2.1.2
  */
 @Slf4j
-public abstract class AbstractJdbcDataSourceProvider extends AbstractDataSourceProvider implements DynamicDataSourceProvider {
+public abstract class AbstractJdbcDataSourceProvider extends AbstractDataSourceProvider {
 
     /**
      * JDBC driver

--- a/src/main/java/com/baomidou/dynamic/datasource/provider/YmlDynamicDataSourceProvider.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/provider/YmlDynamicDataSourceProvider.java
@@ -15,12 +15,13 @@
  */
 package com.baomidou.dynamic.datasource.provider;
 
-import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Map;
 
 import javax.sql.DataSource;
-import java.util.Map;
+
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DataSourceProperty;
+
+import lombok.AllArgsConstructor;
 
 /**
  * YML数据源提供者
@@ -28,7 +29,6 @@ import java.util.Map;
  * @author TaoYu Kanyuxia
  * @since 1.0.0
  */
-@Slf4j
 @AllArgsConstructor
 public class YmlDynamicDataSourceProvider extends AbstractDataSourceProvider {
 

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DataSourceProperty.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DataSourceProperty.java
@@ -15,22 +15,22 @@
  */
 package com.baomidou.dynamic.datasource.spring.boot.autoconfigure;
 
+import javax.sql.DataSource;
+
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.beecp.BeeCpConfig;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.dbcp2.Dbcp2Config;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConfig;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.hikari.HikariCpConfig;
-import lombok.Data;
-import lombok.experimental.Accessors;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-import javax.sql.DataSource;
+import lombok.Data;
+import lombok.experimental.Accessors;
 
 /**
  * @author TaoYu
  * @since 1.2.0
  */
-@Slf4j
 @Data
 @Accessors(chain = true)
 public class DataSourceProperty {

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -51,8 +51,6 @@ import org.springframework.context.annotation.Role;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.util.CollectionUtils;
 
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * 动态数据源核心自动配置类
  *
@@ -63,7 +61,6 @@ import lombok.extern.slf4j.Slf4j;
  * @see DynamicRoutingDataSource
  * @since 1.0.0
  */
-@Slf4j
 @Configuration
 @EnableConfigurationProperties(DynamicDataSourceProperties.class)
 @AutoConfigureBefore(value = DataSourceAutoConfiguration.class,

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
@@ -15,6 +15,9 @@
  */
 package com.baomidou.dynamic.datasource.spring.boot.autoconfigure;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.baomidou.dynamic.datasource.enums.SeataMode;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.beecp.BeeCpConfig;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.dbcp2.Dbcp2Config;
@@ -23,15 +26,13 @@ import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.hikari.HikariCp
 import com.baomidou.dynamic.datasource.strategy.DynamicDataSourceStrategy;
 import com.baomidou.dynamic.datasource.strategy.LoadBalanceDynamicDataSourceStrategy;
 import com.baomidou.dynamic.datasource.toolkit.CryptoUtils;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * DynamicDataSourceProperties
@@ -40,7 +41,6 @@ import java.util.Map;
  * @see DataSourceProperties
  * @since 1.0.0
  */
-@Slf4j
 @Getter
 @Setter
 @ConfigurationProperties(prefix = DynamicDataSourceProperties.PREFIX)

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/druid/DruidConfig.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/druid/DruidConfig.java
@@ -15,18 +15,58 @@
  */
 package com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Accessors;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import static com.alibaba.druid.pool.DruidAbstractDataSource.DEFAULT_INITIAL_SIZE;
+import static com.alibaba.druid.pool.DruidAbstractDataSource.DEFAULT_MAX_EVICTABLE_IDLE_TIME_MILLIS;
+import static com.alibaba.druid.pool.DruidAbstractDataSource.DEFAULT_MAX_WAIT;
+import static com.alibaba.druid.pool.DruidAbstractDataSource.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS;
+import static com.alibaba.druid.pool.DruidAbstractDataSource.DEFAULT_MIN_IDLE;
+import static com.alibaba.druid.pool.DruidAbstractDataSource.DEFAULT_PHY_TIMEOUT_MILLIS;
+import static com.alibaba.druid.pool.DruidAbstractDataSource.DEFAULT_TEST_ON_BORROW;
+import static com.alibaba.druid.pool.DruidAbstractDataSource.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS;
+import static com.alibaba.druid.pool.DruidAbstractDataSource.DEFAULT_WHILE_IDLE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.ASYNC_INIT;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.CLEAR_FILTERS_ENABLE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.FAIL_FAST;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.FILTERS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.INITIAL_SIZE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.INIT_CONNECTION_SQLS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.INIT_GLOBAL_VARIANTS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.INIT_VARIANTS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.KEEP_ALIVE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.KILL_WHEN_SOCKET_READ_TIMEOUT;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.MAX_ACTIVE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.MAX_EVICTABLE_IDLE_TIME_MILLIS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.MAX_POOL_PREPARED_STATEMENT_PER_CONNECTION_SIZE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.MAX_WAIT;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.MAX_WAIT_THREAD_COUNT;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.MIN_EVICTABLE_IDLE_TIME_MILLIS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.MIN_IDLE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.NOT_FULL_TIMEOUT_RETRY_COUNT;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.PHY_TIMEOUT_MILLIS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.POOL_PREPARED_STATEMENTS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.RESET_STAT_ENABLE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.STAT_LOG_SLOW_SQL;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.STAT_MERGE_SQL;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.STAT_SLOW_SQL_LOG_LEVEL;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.STAT_SLOW_SQL_MILLIS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.STAT_SQL_MAX_SIZE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.TEST_ON_BORROW;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.TEST_WHILE_IDLE;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.TIME_BETWEEN_EVICTION_RUNS_MILLIS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.TIME_BETWEEN_LOG_STATS_MILLIS;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.USE_GLOBAL_DATA_SOURCE_STAT;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.USE_UNFAIR_LOCK;
+import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.VALIDATION_QUERY;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import static com.alibaba.druid.pool.DruidAbstractDataSource.*;
-import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.DruidConsts.*;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * Druid参数配置
@@ -37,7 +77,6 @@ import static com.baomidou.dynamic.datasource.spring.boot.autoconfigure.druid.Dr
 @Data
 @Accessors(chain = true)
 @NoArgsConstructor
-@Slf4j
 public class DruidConfig {
 
     private Integer initialSize;

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/hikari/HikariCpConfig.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/hikari/HikariCpConfig.java
@@ -15,10 +15,9 @@
  */
 package com.baomidou.dynamic.datasource.spring.boot.autoconfigure.hikari;
 
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Properties;
+
+import lombok.Data;
 
 /**
  * HikariCp参数配置
@@ -27,7 +26,6 @@ import java.util.Properties;
  * @since 2.4.1
  */
 @Data
-@Slf4j
 public class HikariCpConfig {
 
     private String catalog;

--- a/src/main/java/com/baomidou/dynamic/datasource/support/DataSourceClassResolver.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/support/DataSourceClassResolver.java
@@ -15,8 +15,16 @@
  */
 package com.baomidou.dynamic.datasource.support;
 
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import com.baomidou.dynamic.datasource.annotation.DS;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.core.BridgeMethodResolver;
 import org.springframework.core.MethodClassKey;
@@ -24,17 +32,12 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.util.ClassUtils;
 
-import java.lang.reflect.*;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 /**
  * 数据源解析器
  *
  * @author TaoYu
  * @since 2.3.0
  */
-@Slf4j
 public class DataSourceClassResolver {
 
     private static boolean mpEnabled = false;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**

1. 调整`DsProcessor`解析数据源逻辑，防止如果前面的processor没有匹配到的时候，最终都会走到spel处理报错。
2. spel处理器增加`#spel`前缀，这样处理的时候更明确的知道表达式到底是不是应该由spel处理器来处理。
3. 将之前`DsProcessor`的处理逻辑放到`DsProcessorHandler`去处理，并且由`DsProcessorHandler`来维护所有的`DsProcessor`。
4. `DsProcessor`可用户自己通过继承`DsProcessor`，并且配置`@Bean`来拓展。


**Other information:**



