### PR TITLE
[feat]:使用hikari连接池，部分连接池属性无法生效 #418

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/hikari/HikariCpConfig.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/hikari/HikariCpConfig.java
@@ -15,6 +15,7 @@
  */
 package com.baomidou.dynamic.datasource.spring.boot.autoconfigure.hikari;
 
+import com.zaxxer.hikari.HikariConfigMXBean;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,18 +29,17 @@ import java.util.Properties;
  */
 @Data
 @Slf4j
-public class HikariCpConfig {
+public class HikariCpConfig implements HikariConfigMXBean {
 
     private String catalog;
-    private Long connectionTimeout;
-    private Long validationTimeout;
-    private Long idleTimeout;
-    private Long leakDetectionThreshold;
-    private Long maxLifetime;
-    private Integer maxPoolSize;
-    private Integer minIdle;
-
-    private Long initializationFailTimeout;
+    private volatile long connectionTimeout;
+    private volatile long validationTimeout;
+    private volatile long idleTimeout;
+    private volatile long leakDetectionThreshold;
+    private volatile long maxLifetime;
+    private volatile int maxPoolSize;
+    private volatile int minIdle;
+    private volatile long initializationFailTimeout;
     private String connectionInitSql;
     private String connectionTestQuery;
     private String dataSourceClassName;
@@ -52,7 +52,9 @@ public class HikariCpConfig {
     private Boolean isAllowPoolSuspension;
     private Properties dataSourceProperties;
     private Properties healthCheckProperties;
-
+    private String password;
+    private String poolName;
+    private String username;
     /**
      * 高版本才有
      */
@@ -60,4 +62,64 @@ public class HikariCpConfig {
     private String exceptionOverrideClassName;
     private Long keepaliveTime;
     private Boolean sealed;
+
+    @Override
+    public void setConnectionTimeout(long connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    @Override
+    public void setValidationTimeout(long validationTimeout) {
+        this.validationTimeout = validationTimeout;
+    }
+
+    @Override
+    public void setIdleTimeout(long idleTimeout) {
+        this.idleTimeout = idleTimeout;
+    }
+
+    @Override
+    public void setLeakDetectionThreshold(long leakDetectionThreshold) {
+        this.leakDetectionThreshold = leakDetectionThreshold;
+    }
+
+    @Override
+    public void setMaxLifetime(long maxLifetime) {
+        this.maxLifetime = maxLifetime;
+    }
+
+    @Override
+    public int getMinimumIdle() {
+        return minIdle;
+    }
+
+    @Override
+    public void setMinimumIdle(int minIdle) {
+        this.minIdle = minIdle;
+    }
+
+    @Override
+    public int getMaximumPoolSize() {
+        return maxPoolSize;
+    }
+
+    @Override
+    public void setMaximumPoolSize(int maxPoolSize) {
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    @Override
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public String getPoolName() {
+        return this.poolName;
+    }
 }


### PR DESCRIPTION
https://github.com/baomidou/dynamic-datasource-spring-boot-starter/issues/418
使用hikari源码方式提供属性赋值方法

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
- 考虑已经有的存量项目，原有的属性一定不能失效、废弃，必须保留
- 额外添加新的方法，以适配hikari原有的参数设置
- 可以使用简单的方式，仅添加MaximumPoolSize、MinimumIdle的参数设置，但是考虑到后续与hikari官方的适配性，最后还是implements了HikariConfigMXBean
- 参数Long->volatile long，保持与hikari源码一致性

**Other information:**



