### PR TITLE
fix: @DSTransactional 注解回滚时的判断，比如配置了noRollbackFor，那么有些异常是不用回滚的

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicLocalTransactionInterceptor.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicLocalTransactionInterceptor.java
@@ -20,6 +20,9 @@ import com.baomidou.dynamic.datasource.tx.TransactionContext;
 import lombok.extern.slf4j.Slf4j;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.transaction.interceptor.TransactionAttribute;
+import org.springframework.transaction.interceptor.TransactionAttributeSource;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,26 +31,52 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class DynamicLocalTransactionInterceptor implements MethodInterceptor {
 
+    private final TransactionAttributeSource transactionAttributeSource;
+
+    public DynamicLocalTransactionInterceptor() {
+        this(null);
+    }
+
+    public DynamicLocalTransactionInterceptor(TransactionAttributeSource transactionAttributeSource) {
+        this.transactionAttributeSource = transactionAttributeSource;
+    }
+
     @Override
     public Object invoke(MethodInvocation methodInvocation) throws Throwable {
         if (!StringUtils.isEmpty(TransactionContext.getXID())) {
             return methodInvocation.proceed();
         }
-        boolean state = true;
+        boolean commitFlag = true;
         Object o;
         LocalTxUtil.startTransaction();
         try {
             o = methodInvocation.proceed();
         } catch (Exception e) {
-            state = false;
+            // 检查该异常是否可以回滚
+            commitFlag = determineWhetherCommit(methodInvocation, e);
             throw e;
         } finally {
-            if (state) {
+            if (commitFlag) {
                 LocalTxUtil.commit();
             } else {
                 LocalTxUtil.rollback();
             }
         }
         return o;
+    }
+
+    private boolean determineWhetherCommit(MethodInvocation invocation, Exception e) {
+        if (transactionAttributeSource == null) {
+            return false;
+        }
+        Class<?> targetClass = invocation.getThis() != null ? AopUtils.getTargetClass(invocation.getThis()) : null;
+        TransactionAttribute transactionAttribute = transactionAttributeSource.getTransactionAttribute(invocation.getMethod(), targetClass);
+
+        if (transactionAttribute == null) {
+            return false;
+        }
+
+        boolean rollback = transactionAttribute.rollbackOn(e);
+        return !rollback;
     }
 }

--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -47,6 +47,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Role;
 import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.transaction.interceptor.TransactionAttributeSource;
 import org.springframework.util.CollectionUtils;
 
 import javax.sql.DataSource;
@@ -111,8 +112,8 @@ public class DynamicDataSourceAutoConfiguration implements InitializingBean {
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     @Bean
     @ConditionalOnProperty(prefix = DynamicDataSourceProperties.PREFIX, name = "seata", havingValue = "false", matchIfMissing = true)
-    public Advisor dynamicTransactionAdvisor() {
-        DynamicLocalTransactionInterceptor interceptor = new DynamicLocalTransactionInterceptor();
+    public Advisor dynamicTransactionAdvisor(TransactionAttributeSource transactionAttributeSource) {
+        DynamicLocalTransactionInterceptor interceptor = new DynamicLocalTransactionInterceptor(transactionAttributeSource);
         return new DynamicDataSourceAnnotationAdvisor(interceptor, DSTransactional.class);
     }
 


### PR DESCRIPTION
Signed-off-by: old Cao <clk5858@163.com>

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
对于@DSTransactional注解，操作多个数据源的捕获异常的时候，不能直接回滚，需要动态判断@Transactional注解的配置，然后决定是回滚(rollback)还是提交(commit)

**Other information:**



