### PR TITLE
让默认的DynamicDataSourceProvider优先级为0

### DIFF
--- a/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -47,6 +47,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Role;
 import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.core.annotation.Order;
 import org.springframework.util.CollectionUtils;
 
 import javax.sql.DataSource;
@@ -81,6 +82,7 @@ public class DynamicDataSourceAutoConfiguration implements InitializingBean {
     }
 
     @Bean
+    @Order(0)
     public DynamicDataSourceProvider ymlDynamicDataSourceProvider() {
         return new YmlDynamicDataSourceProvider(properties.getDatasource());
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**

设定默认的 `ymlDynamicDataSourceProvider` 为 `@Order(0)`，从而使得使用方可以准确地控制 `DynamicRoutingDataSource` 中的 `providers` 注入顺序，以实现同名数据源按照优先级覆盖的效果



