### PR TITLE
fix(sec): upgrade org.apache.commons:commons-dbcp2 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -55,7 +54,7 @@
         <hikariCp.version>2.4.13</hikariCp.version>
         <druid.version>1.2.8</druid.version>
         <beeCp.version>3.2.9</beeCp.version>
-        <dbcp2.version>2.8.0</dbcp2.version>
+        <dbcp2.version>2.9.0</dbcp2.version>
         <p6spy.version>3.9.1</p6spy.version>
         <seata.version>1.4.2</seata.version>
         <lombok.version>1.18.22</lombok.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.commons:commons-dbcp2 2.8.0
- [MPS-2022-12024](https://www.oscs1024.com/hd/MPS-2022-12024)


### What did I do？
Upgrade org.apache.commons:commons-dbcp2 from 2.8.0 to 2.9.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS