### PR TITLE
[Feature]Druid DataSource timeBetweenConnectErrorMillis Config

### DIFF
--- a/core/src/main/java/com/baomidou/dynamic/datasource/creator/DruidDataSourceCreator.java
+++ b/core/src/main/java/com/baomidou/dynamic/datasource/creator/DruidDataSourceCreator.java
@@ -202,6 +202,12 @@ public class DruidDataSourceCreator extends AbstractDataSourceCreator implements
             dataSource.setTransactionQueryTimeout(transactionQueryTimeout);
         }
 
+        Long timeBetweenConnectErrorMillis =
+                config.getTimeBetweenConnectErrorMillis() == null ? gConfig.getTimeBetweenConnectErrorMillis() : config.getTimeBetweenConnectErrorMillis();
+        if (timeBetweenConnectErrorMillis != null) {
+            dataSource.setTimeBetweenConnectErrorMillis(timeBetweenConnectErrorMillis);
+        }
+
         // since druid 1.2.12
         Integer connectTimeout = config.getConnectTimeout() == null ? gConfig.getConnectTimeout() : config.getConnectTimeout();
         if (connectTimeout != null) {

--- a/core/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/druid/DruidConfig.java
+++ b/core/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/druid/DruidConfig.java
@@ -80,6 +80,7 @@ public class DruidConfig {
     private String publicKey;
     private Integer connectTimeout;  // millisecond
     private Integer socketTimeout;   // millisecond
+    private Long timeBetweenConnectErrorMillis; // millisecond
 
     private Map<String, Object> wall = new HashMap<>();
     private Map<String, Object> slf4j = new HashMap<>();


### PR DESCRIPTION
你好，基于此issues https://github.com/baomidou/dynamic-datasource-spring-boot-starter/issues/487 发现目前项目确实缺少关于 druid 的timeBetweenConnectErrorMillis 的配置。

我在本地 dynamic-datasource-samples 项目中实际添加属性测试后，初始化后的 DruidDataSource 的 timeBetweenConnectErrorMillis  依旧采用了默认值 500，故提了此pull Request。

![image](https://user-images.githubusercontent.com/16573126/226638749-912594f8-bda4-44aa-b0f0-1ce97a255348.png)

另外，我觉得后续需要实时补齐各类DataSource 的配置实属不是一件简单的事情，会考虑继承各类DataSource的配置这种方式，从而后续只需要更新 DataSource 的版本么？

期待你的回复。

