### PR TITLE
fix: NPE when add datasources from provider. 

### DIFF
--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/DynamicRoutingDataSource.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/DynamicRoutingDataSource.java
@@ -222,7 +222,10 @@ public class DynamicRoutingDataSource extends AbstractRoutingDataSource implemen
         // 添加并分组数据源
         Map<String, DataSource> dataSources = new HashMap<>(16);
         for (DynamicDataSourceProvider provider : providers) {
-            dataSources.putAll(provider.loadDataSources());
+            Map<String, DataSource> dsMap = provider.loadDataSources();
+            if (dsMap != null) {
+                dataSources.putAll(dsMap);
+            }
         }
         for (Map.Entry<String, DataSource> dsItem : dataSources.entrySet()) {
             addDataSource(dsItem.getKey(), dsItem.getValue());


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**

`com.baomidou.dynamic.datasource.provider.DynamicDataSourceProvider#loadDataSources` 可能会返回null，进而在`com.baomidou.dynamic.datasource.DynamicRoutingDataSource#afterPropertiesSet`中触发npe问题

比如`com.baomidou.dynamic.datasource.provider.AbstractJdbcDataSourceProvider#loadDataSources`的实现会在出现db异常的时候返回一个null

**Other information:**



