### PR TITLE
REQUIRED主事务内多个NESTED次事务不提交事务bug

### DIFF
--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/tx/ConnectionFactory.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/tx/ConnectionFactory.java
@@ -182,7 +182,7 @@ public class ConnectionFactory {
 
     public static boolean hasSavepoint(String xid) {
         Map<String, List<SavePointHolder>> savePointMap = SAVEPOINT_CONNECTION_HOLDER.get();
-        return !CollectionUtils.isEmpty(savePointMap.get(xid));
+        return !CollectionUtils.isEmpty(savePointMap.get(xid)) && savePointMap.get(xid).stream().anyMatch(savePointHolder -> !CollectionUtils.isEmpty(savePointHolder.getSavePoints()));
     }
 
 }

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/tx/ConnectionFactory.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/tx/ConnectionFactory.java
@@ -182,7 +182,8 @@ public class ConnectionFactory {
 
     public static boolean hasSavepoint(String xid) {
         Map<String, List<SavePointHolder>> savePointMap = SAVEPOINT_CONNECTION_HOLDER.get();
-        return !CollectionUtils.isEmpty(savePointMap.get(xid)) && savePointMap.get(xid).stream().anyMatch(savePointHolder -> !CollectionUtils.isEmpty(savePointHolder.getSavePoints()));
+        List<SavePointHolder> savePointHolders = savePointMap.get(xid);
+        return !CollectionUtils.isEmpty(savePointHolders) && savePointHolders.stream().anyMatch(savePointHolder -> !CollectionUtils.isEmpty(savePointHolder.getSavePoints()));
     }
 
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The description of the PR:**
https://github.com/dynamic-datasource/dynamic-datasource-samples.git
示例代码中,代码内两个service添加事务
@DS("product")
@DSTransactional(propagation = DsPropagation.NESTED)
![image](https://github.com/baomidou/dynamic-datasource-spring-boot-starter/assets/51375741/547299a0-374c-4dc3-b124-793c4ce2550a)
导致最后主事务判断出错仍不提交事务
![image-20230718104811196](https://github.com/baomidou/dynamic-datasource-spring-boot-starter/assets/51375741/67f20544-e4a1-4a4c-82a6-b3612a63bfd7)
并且tx不关闭,下次进入锁死
**Other information:**



