### PR TITLE
fix:主事务内多个嵌套事务，导致影响主事务提交|回滚

### DIFF
--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/tx/ConnectionFactory.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/tx/ConnectionFactory.java
@@ -117,7 +117,7 @@ public class ConnectionFactory {
                         Iterator<SavePointHolder> iterator = savePointHolders.iterator();
                         while (iterator.hasNext()) {
                             SavePointHolder savePointHolder = iterator.next();
-                            if (savePointHolder.releaseSavepoint() <= 0) {
+                            if (savePointHolder.releaseSavepoint()) {
                                 iterator.remove();
                             }
                         }
@@ -128,7 +128,7 @@ public class ConnectionFactory {
                             SavePointHolder savePointHolder = iterator.next();
                             ConnectionProxy connectionProxy = savePointHolder.getConnectionProxy();
                             markedConnectionProxy.add(connectionProxy);
-                            if (savePointHolder.rollbackSavePoint() <= 0) {
+                            if (savePointHolder.rollbackSavePoint()) {
                                 iterator.remove();
                             }
                         }
@@ -221,15 +221,7 @@ public class ConnectionFactory {
     public static boolean hasSavepoint(String xid) {
         Map<String, List<SavePointHolder>> savePointMap = SAVEPOINT_CONNECTION_HOLDER.get();
         List<SavePointHolder> savePointHolders = savePointMap.get(xid);
-        if (savePointHolders == null || savePointHolders.isEmpty()) {
-            return false;
-        }
-        for (SavePointHolder savePointHolder : savePointHolders) {
-            if (!CollectionUtils.isEmpty(savePointHolder.getSavePoints())) {
-                return true;
-            }
-        }
-        return false;
+        return !CollectionUtils.isEmpty(savePointHolders);
     }
 
 }

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/tx/SavePointHolder.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/tx/SavePointHolder.java
@@ -16,6 +16,8 @@
 package com.baomidou.dynamic.datasource.tx;
 
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.sql.SQLException;
 import java.sql.SQLTransientConnectionException;
 import java.sql.Savepoint;
@@ -27,6 +29,7 @@ import java.util.List;
  *
  * @author zp
  */
+@Slf4j
 public class SavePointHolder {
     /**
      * savepoint name prefix
@@ -72,14 +75,15 @@ public class SavePointHolder {
      * @return savepoint index
      * @throws SQLException SQLException
      */
-    public int releaseSavepoint() throws SQLException {
+    public boolean releaseSavepoint() throws SQLException {
         Savepoint savepoint = savepoints.pollLast();
         if (savepoint != null) {
             connectionProxy.releaseSavepoint(savepoint);
             String savepointName = savepoint.getSavepointName();
-            return Integer.parseInt(savepointName.substring(SAVEPOINT_NAME_PREFIX.length()));
+            log.info("dynamic-datasource releaseSavepoint [{}]", savepointName);
+            return savepoints.isEmpty();
         }
-        return -1;
+        return true;
     }
 
     /**
@@ -88,14 +92,15 @@ public class SavePointHolder {
      * @return savepoint index
      * @throws SQLException SQLException
      */
-    public int rollbackSavePoint() throws SQLException {
+    public boolean rollbackSavePoint() throws SQLException {
         Savepoint savepoint = savepoints.pollLast();
         if (savepoint != null) {
             connectionProxy.rollback(savepoint);
             String savepointName = savepoint.getSavepointName();
-            return Integer.parseInt(savepointName.substring(SAVEPOINT_NAME_PREFIX.length()));
+            log.info("dynamic-datasource rollbackSavePoint [{}]", savepointName);
+            return savepoints.isEmpty();
         }
-        return -1;
+        return true;
     }
 
     /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [√ ] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
   这个主要原因是由于当初想通过每个连接的保存点名称计数，根据调用栈的深度来释放掉SavePointHolder对象，当到达外层调用栈时最后一个savepoint会返回0(即第一次为savepoint0)，但是如果某一层级多个嵌套事务的话就会导致order连接创建出savepoint计数为1的保存点，所以当保存点释放、回滚时会出现即使SavePointHolder持有的savepoint集合为空(已经释放回滚干净)但计数未<=0不满足条件，无法删除空持有的SavePointHolder对象，因此影响主事务提交|回滚。今天那个pr虽然会再次判断这个savePointHolder持有的savepoints集合是否为空来作为存在保存点的条件但是仍然会多出一个空持有对象，因此通过将保存点释放、回滚时删除savepoint集合持有对象(SavePointHolder)的条件改为为SavePointHolder中savepoints集合是否为空。

**Other information:**
#531 


